### PR TITLE
fix:모달 버그 해결, feat:모달 테스트 페이지 추가

### DIFF
--- a/src/components/basicComponents/basicModal/BasicModal.tsx
+++ b/src/components/basicComponents/basicModal/BasicModal.tsx
@@ -1,8 +1,8 @@
 // BasicModal.tsx
 import { createPortal } from 'react-dom'
 import { AnimatePresence, motion } from 'framer-motion'
-import { useCallback, useEffect, useRef } from 'react'
-import { useNavigate, useLocation, Outlet } from 'react-router'
+import { useEffect, useRef } from 'react'
+import { useLocation, Outlet } from 'react-router'
 import { storeModalOpen } from '@/store/storeModalOpen'
 import ModalHeader from '@/components/modal/ModalHeader'
 import { useModal } from '@/hooks/useModal'

--- a/src/components/basicComponents/basicModal/BasicModal.tsx
+++ b/src/components/basicComponents/basicModal/BasicModal.tsx
@@ -3,8 +3,8 @@ import { createPortal } from 'react-dom'
 import { AnimatePresence, motion } from 'framer-motion'
 import { useCallback, useEffect, useRef } from 'react'
 import { useNavigate, useLocation, Outlet } from 'react-router'
-import { ChevronLeft } from 'lucide-react'
 import { storeModalOpen } from '@/store/storeModalOpen'
+import ModalHeader from '@/components/modal/ModalHeader'
 
 /**
  *
@@ -27,23 +27,36 @@ export default function BasicModal() {
   const modalRef = useRef<HTMLDivElement>(null)
 
   // Zustand store
-  const { isModalOpen, setModalOpen: SetModalOpen } = storeModalOpen()
-  const prevPath = location.state?.prevPath || '/'
+  const isModalOpen = storeModalOpen((state) => state.modalState.isModalOpen)
+  const setModalOpen = storeModalOpen((state) => state.setModalState)
+
+  // navigate를 통해 들어온 값들
+  const { prevPath, title, subTitle } = storeModalOpen().modalState
+
+  // 무한 랜더링 방지 및 린트 회피용 ref
+  const setModalOpenRef = useRef(setModalOpen)
+  const isModalOpenRef = useRef(isModalOpen)
 
   // 닫기 로직
-  const handleClose = useCallback(() => {
-    SetModalOpen(false)
+  const handleCloseRef = useRef(() => {
+    setModalOpen({ isModalOpen: false })
     navigate(prevPath, { replace: true })
-  }, [SetModalOpen, navigate, prevPath])
+  })
+  const handleClose = useCallback(() => {
+    handleCloseRef.current()
+  }, [])
 
   // location이 변경될 때마다 모달 상태 확인
   useEffect(() => {
+    const smorc = setModalOpenRef.current
+    const imorc = isModalOpenRef.current
+
     const isModalRoute = location.pathname.startsWith('/modal')
-    if (isModalRoute && !isModalOpen) {
-      SetModalOpen(true)
+    if (isModalRoute && !imorc) {
+      smorc({ isModalOpen: true })
       document.body.style.overflow = 'hidden'
-    } else if (!isModalRoute && isModalOpen) {
-      SetModalOpen(false)
+    } else if (!isModalRoute && imorc) {
+      smorc({ isModalOpen: false })
       document.body.style.overflow = 'unset'
     }
 
@@ -55,19 +68,19 @@ export default function BasicModal() {
     // 위의 else if는 경로 이동에 따른 모달 상태관리
     // 아래의 return 클린업 함수는 비정상 종료 대응용 안전장치
     return () => {
-      SetModalOpen(false)
+      smorc({ isModalOpen: false })
       document.body.style.overflow = 'unset'
     }
-  }, [location.pathname, isModalOpen, SetModalOpen])
+  }, [location.pathname])
 
   // esc 누를시 이전 경로로 이동
   useEffect(() => {
     const handleEsc = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') handleClose()
+      if (e.key === 'Escape') handleCloseRef.current()
     }
     window.addEventListener('keydown', handleEsc)
     return () => window.removeEventListener('keydown', handleEsc)
-  }, [handleClose])
+  }, [])
 
   // 포커스 트랩
   useEffect(() => {
@@ -117,15 +130,12 @@ export default function BasicModal() {
             transition={{ type: 'spring', stiffness: 280, damping: 25 }}
             onClick={(e) => e.stopPropagation()}
           >
-            <div className="sticky top-0 z-10 flex items-center border-b bg-white/90 p-4 backdrop-blur-sm">
-              <ChevronLeft
-                onClick={handleClose}
-                className="h-6 w-6 cursor-pointer text-gray-500 transition-colors hover:text-gray-700"
-                aria-label="창 닫기"
-              />
-            </div>
-
             <div className="max-h-[calc(90vh-3.5rem)] overflow-y-auto p-4">
+              <ModalHeader
+                title={title}
+                subTitle={subTitle}
+                onClose={handleClose}
+              />
               <Outlet />
             </div>
           </motion.div>

--- a/src/components/basicComponents/basicModal/BasicModal.tsx
+++ b/src/components/basicComponents/basicModal/BasicModal.tsx
@@ -29,13 +29,13 @@ export default function BasicModal() {
 
   // Zustand store
   const isModalOpen = storeModalOpen((state) => state.modalState.isModalOpen)
-  const setModalOpen = storeModalOpen((state) => state.setModalState)
+  const setModalState = storeModalOpen((state) => state.setModalState)
 
   // navigate를 통해 들어온 값들
   const { title, subTitle } = storeModalOpen().modalState
 
   // 무한 랜더링 방지 및 린트 회피용 ref
-  const setModalOpenRef = useRef(setModalOpen)
+  const setModalOpenRef = useRef(setModalState)
   const isModalOpenRef = useRef(isModalOpen)
   const closeModalRef = useRef(closeModal)
 
@@ -124,11 +124,7 @@ export default function BasicModal() {
             onClick={(e) => e.stopPropagation()}
           >
             <div className="max-h-[calc(90vh-3.5rem)] overflow-y-auto p-4">
-              <ModalHeader
-                title={title}
-                subTitle={subTitle}
-                onClose={() => closeModalRef.current()}
-              />
+              <ModalHeader title={title} subTitle={subTitle} />
               <Outlet />
             </div>
           </motion.div>

--- a/src/components/basicComponents/basicModal/BasicModal.tsx
+++ b/src/components/basicComponents/basicModal/BasicModal.tsx
@@ -5,6 +5,7 @@ import { useCallback, useEffect, useRef } from 'react'
 import { useNavigate, useLocation, Outlet } from 'react-router'
 import { storeModalOpen } from '@/store/storeModalOpen'
 import ModalHeader from '@/components/modal/ModalHeader'
+import { useModal } from '@/hooks/useModal'
 
 /**
  *
@@ -22,29 +23,21 @@ import ModalHeader from '@/components/modal/ModalHeader'
  * ```
  */
 export default function BasicModal() {
-  const navigate = useNavigate()
   const location = useLocation()
   const modalRef = useRef<HTMLDivElement>(null)
+  const { closeModal } = useModal()
 
   // Zustand store
   const isModalOpen = storeModalOpen((state) => state.modalState.isModalOpen)
   const setModalOpen = storeModalOpen((state) => state.setModalState)
 
   // navigate를 통해 들어온 값들
-  const { prevPath, title, subTitle } = storeModalOpen().modalState
+  const { title, subTitle } = storeModalOpen().modalState
 
   // 무한 랜더링 방지 및 린트 회피용 ref
   const setModalOpenRef = useRef(setModalOpen)
   const isModalOpenRef = useRef(isModalOpen)
-
-  // 닫기 로직
-  const handleCloseRef = useRef(() => {
-    setModalOpen({ isModalOpen: false })
-    navigate(prevPath, { replace: true })
-  })
-  const handleClose = useCallback(() => {
-    handleCloseRef.current()
-  }, [])
+  const closeModalRef = useRef(closeModal)
 
   // location이 변경될 때마다 모달 상태 확인
   useEffect(() => {
@@ -76,7 +69,7 @@ export default function BasicModal() {
   // esc 누를시 이전 경로로 이동
   useEffect(() => {
     const handleEsc = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') handleCloseRef.current()
+      if (e.key === 'Escape') closeModalRef.current()
     }
     window.addEventListener('keydown', handleEsc)
     return () => window.removeEventListener('keydown', handleEsc)
@@ -118,7 +111,7 @@ export default function BasicModal() {
           animate="visible"
           exit="exit"
           transition={{ duration: 0.25 }}
-          onClick={handleClose}
+          onClick={() => closeModalRef.current()}
         >
           <motion.div
             className="relative max-h-[90vh] w-full max-w-md overflow-hidden rounded-xl bg-white shadow-2xl"
@@ -134,7 +127,7 @@ export default function BasicModal() {
               <ModalHeader
                 title={title}
                 subTitle={subTitle}
-                onClose={handleClose}
+                onClose={() => closeModalRef.current()}
               />
               <Outlet />
             </div>

--- a/src/components/modal/ModalHeader.tsx
+++ b/src/components/modal/ModalHeader.tsx
@@ -4,10 +4,9 @@ import { X } from 'lucide-react'
 type ModalHeaderProps = {
   title: string
   subTitle?: string | null
-  onClose: () => void
 }
 
-const ModalHeader = ({ title, subTitle = null, onClose }: ModalHeaderProps) => {
+const ModalHeader = ({ title, subTitle = null }: ModalHeaderProps) => {
   const { closeModal } = useModal()
 
   const handleClickCancel = (e: React.MouseEvent) => {
@@ -21,8 +20,8 @@ const ModalHeader = ({ title, subTitle = null, onClose }: ModalHeaderProps) => {
         <h1 className="text-lg font-semibold">{title}</h1>
         <h2 className="text-sm font-normal text-gray-500">{subTitle}</h2>
       </div>
-      <button onClick={(e) => handleClickCancel(e)}>
-        <X size={18} onClick={() => onClose()} className="cursor-pointer" />
+      <button onClick={(e) => handleClickCancel(e)} className="cursor-pointer">
+        <X size={18} />
       </button>
     </header>
   )

--- a/src/components/modal/ModalHeader.tsx
+++ b/src/components/modal/ModalHeader.tsx
@@ -1,17 +1,18 @@
-import { storeModalOpen } from '@/store/storeModalOpen'
+import { useModal } from '@/hooks/useModal'
 import { X } from 'lucide-react'
 
 type ModalHeaderProps = {
   title: string
   subTitle?: string | null
+  onClose: () => void
 }
 
-const ModalHeader = ({ title, subTitle = null }: ModalHeaderProps) => {
-  const { setModalOpen: setModalOpen } = storeModalOpen()
+const ModalHeader = ({ title, subTitle = null, onClose }: ModalHeaderProps) => {
+  const { closeModal } = useModal()
 
   const handleClickCancel = (e: React.MouseEvent) => {
     e.preventDefault()
-    setModalOpen(false)
+    closeModal()
   }
 
   return (
@@ -21,7 +22,7 @@ const ModalHeader = ({ title, subTitle = null }: ModalHeaderProps) => {
         <h2 className="text-sm font-normal text-gray-500">{subTitle}</h2>
       </div>
       <button onClick={(e) => handleClickCancel(e)}>
-        <X size={18} />
+        <X size={18} onClick={() => onClose()} className="cursor-pointer" />
       </button>
     </header>
   )

--- a/src/components/modal/datePicker/DatePickerFooter.tsx
+++ b/src/components/modal/datePicker/DatePickerFooter.tsx
@@ -1,4 +1,4 @@
-import { storeModalOpen } from '@/store/storeModalOpen'
+import { useModal } from '@/hooks/useModal'
 import { BasicButton } from '../../basicComponents/BasicButton/BasicButton'
 
 type DatePickerFooterProps = {
@@ -6,11 +6,11 @@ type DatePickerFooterProps = {
 }
 
 const DatePickerFooter = ({ selected }: DatePickerFooterProps) => {
-  const { setModalOpen } = storeModalOpen()
+  const { closeModal } = useModal()
 
   const handleClickCancel = (e: React.MouseEvent) => {
     e.preventDefault()
-    setModalOpen(false)
+    closeModal()
   }
   return (
     <footer className="flex w-full items-center justify-between border-t border-gray-300 p-6">

--- a/src/components/modal/reviewPosting/ReviewPostingModal.tsx
+++ b/src/components/modal/reviewPosting/ReviewPostingModal.tsx
@@ -1,8 +1,8 @@
-import { storeModalOpen } from '@/store/storeModalOpen'
 import type { StudyGroup } from '../../../types/StudyGroup'
 import { BasicButton } from '../../basicComponents/BasicButton/BasicButton'
 import ReviewRating from './ReviewRating'
 import ReviewText from './ReviewText'
+import { useModal } from '@/hooks/useModal'
 // import { useLoaderData } from 'react-router'
 
 const ReviewPostingModal = () => {
@@ -28,12 +28,11 @@ const ReviewPostingModal = () => {
   const endYear = end.getFullYear()
   const endMonth = end.getMonth() + 1
   const endDate = end.getDate()
-
-  const { setModalOpen: setModalOpen } = storeModalOpen()
+  const { closeModal } = useModal()
 
   const handleClickCancel = (e: React.MouseEvent) => {
     e.preventDefault()
-    setModalOpen(false)
+    closeModal()
   }
 
   return (

--- a/src/components/navBar/NavBar.tsx
+++ b/src/components/navBar/NavBar.tsx
@@ -15,7 +15,7 @@ export default function NavbarLayout() {
         </div>
       </nav>
 
-      <main className="flex w-full flex-1 items-center justify-center bg-gray-50">
+      <main className="mt-[65px] flex w-full flex-1 items-center justify-center bg-gray-50">
         <Outlet />
       </main>
     </div>

--- a/src/hooks/useModal.ts
+++ b/src/hooks/useModal.ts
@@ -34,6 +34,24 @@ export function useModal() {
     })
   }
 
+  /**
+   * 모달에서 다른 모달로 이동(prevPath 옵션을 위해 분리)
+   * 모달 > 다른 모달 이동 완료된 상태에서 뒤로가기 : navigate(-1)
+   * 모달 > 다른 모달 이동 완료된 상태에서 모달 닫기 : closeModal()
+   */
+  const modalToModal = (
+    modalPath: string,
+    title: string,
+    subTitle?: string
+  ) => {
+    navigate(modalPath)
+    storeModalOpen.getState().setModalState({
+      isModalOpen: true,
+      title: title,
+      subTitle: subTitle,
+    })
+  }
+
   // 모달 닫기
   const closeModal = () => {
     const { prevPath } = storeModalOpen.getState().modalState
@@ -54,5 +72,5 @@ export function useModal() {
     }
   }, [location.pathname])
 
-  return { openModal, closeModal } as const
+  return { openModal, closeModal, modalToModal } as const
 }

--- a/src/hooks/useModal.ts
+++ b/src/hooks/useModal.ts
@@ -26,7 +26,7 @@ export function useModal() {
   const openModal = (modalPath: string, title: string, subTitle?: string) => {
     const currentPath = location.pathname
     navigate(modalPath)
-    storeModalOpen.getState().setModalState({
+    storeModalOpen.getState().setIsModalState({
       isModalOpen: true,
       prevPath: currentPath,
       title: title,
@@ -45,7 +45,7 @@ export function useModal() {
     subTitle?: string
   ) => {
     navigate(modalPath)
-    storeModalOpen.getState().setModalState({
+    storeModalOpen.getState().setIsModalState({
       isModalOpen: true,
       title: title,
       subTitle: subTitle,

--- a/src/hooks/useModal.ts
+++ b/src/hooks/useModal.ts
@@ -26,7 +26,7 @@ export function useModal() {
   const openModal = (modalPath: string, title: string, subTitle?: string) => {
     const currentPath = location.pathname
     navigate(modalPath)
-    storeModalOpen.getState().setIsModalState({
+    storeModalOpen.getState().setModalState({
       isModalOpen: true,
       prevPath: currentPath,
       title: title,
@@ -45,7 +45,7 @@ export function useModal() {
     subTitle?: string
   ) => {
     navigate(modalPath)
-    storeModalOpen.getState().setIsModalState({
+    storeModalOpen.getState().setModalState({
       isModalOpen: true,
       title: title,
       subTitle: subTitle,

--- a/src/hooks/useModal.ts
+++ b/src/hooks/useModal.ts
@@ -1,3 +1,5 @@
+import { storeModalOpen } from '@/store/storeModalOpen'
+import { useEffect, useRef } from 'react'
 import { useNavigate, useLocation } from 'react-router'
 
 /**
@@ -18,12 +20,39 @@ import { useNavigate, useLocation } from 'react-router'
 export function useModal() {
   const navigate = useNavigate()
   const location = useLocation()
+  const isClosingRef = useRef(false)
 
-  const openModal = (modalPath: string) => {
-    navigate(modalPath, {
-      state: { prevPath: location.pathname },
+  // 모달 열기
+  const openModal = (modalPath: string, title: string, subTitle?: string) => {
+    const currentPath = location.pathname
+    navigate(modalPath)
+    storeModalOpen.getState().setModalState({
+      isModalOpen: true,
+      prevPath: currentPath,
+      title: title,
+      subTitle: subTitle,
     })
   }
 
-  return { openModal } as const
+  // 모달 닫기
+  const closeModal = () => {
+    const { prevPath } = storeModalOpen.getState().modalState
+    if (prevPath) {
+      isClosingRef.current = true
+      navigate(prevPath, { replace: true })
+    }
+  }
+
+  // 모달 닫을때 상태 초기화
+  // 기존에 clearModal이 과도하게 실행되는 문제가 있었으나, isClosingRef 참조형으로 변경하여 해결
+  useEffect(() => {
+    const { modalState, clearModal } = storeModalOpen.getState()
+
+    if (isClosingRef.current && location.pathname === modalState.prevPath) {
+      clearModal()
+      isClosingRef.current = false
+    }
+  }, [location.pathname])
+
+  return { openModal, closeModal } as const
 }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -10,34 +10,41 @@ import TestY from './test/TestY'
 import BasicModal from './components/basicComponents/basicModal/BasicModal'
 import ReviewPostingModal from './components/modal/reviewPosting/ReviewPostingModal'
 import DatePickerModal from './components/modal/datePicker/DatePickerModal'
+import TestModal from './test/TestModal'
 
 const router = createBrowserRouter([
   {
     path: '/',
     Component: App,
-    children: [],
-  },
-  {
-    path: '/modal',
-    Component: BasicModal,
     children: [
       {
-        path: '/modal/review_posting',
-        loader: () => {},
-        Component: ReviewPostingModal,
+        path: '/testModal',
+        Component: TestModal,
       },
       {
-        path: '/modal/review_detail',
-      },
-      {
-        path: '/modal/date_picker',
-        Component: DatePickerModal,
-      },
-      {
-        path: '/modal/choosing_lecture',
+        path: '/modal',
+        Component: BasicModal,
+        children: [
+          {
+            path: '/modal/review_posting',
+            loader: () => {},
+            Component: ReviewPostingModal,
+          },
+          {
+            path: '/modal/review_detail',
+          },
+          {
+            path: '/modal/date_picker',
+            Component: DatePickerModal,
+          },
+          {
+            path: '/modal/choosing_lecture',
+          },
+        ],
       },
     ],
   },
+
   {
     path: '/testD',
     Component: TestD,

--- a/src/store/storeModalOpen.ts
+++ b/src/store/storeModalOpen.ts
@@ -1,10 +1,28 @@
 import { create } from 'zustand'
 
-interface ModalOpen {
+type ModalState = {
   isModalOpen: boolean
-  setModalOpen: (isOpen: boolean) => void
+  prevPath: string
+  title: string
+  subTitle?: string
 }
-export const storeModalOpen = create<ModalOpen>((set) => ({
+interface storeModalState {
+  modalState: ModalState
+
+  setModalState: (state: Partial<ModalState>) => void
+  clearModal: () => void
+}
+
+const initState: ModalState = {
   isModalOpen: false,
-  setModalOpen: (isOpen) => set(() => ({ isModalOpen: isOpen })),
+  prevPath: '',
+  title: '',
+  subTitle: '',
+}
+
+export const storeModalOpen = create<storeModalState>((set) => ({
+  modalState: initState,
+  setModalState: (newState) =>
+    set((cur) => ({ modalState: { ...cur.modalState, ...newState } })),
+  clearModal: () => set(() => ({ modalState: initState })),
 }))

--- a/src/test/TestG.tsx
+++ b/src/test/TestG.tsx
@@ -1,12 +1,33 @@
 import NavbarLayout from '@/components/navBar/NavBar'
+import { useModal } from '@/hooks/useModal'
 import { Route, Routes } from 'react-router'
 
 function TestG() {
   return (
     <Routes>
-      <Route path="/" element={<NavbarLayout />}></Route>
+      <Route path="/" element={<NavbarLayout />}>
+        <Route path="/" element={<ModalTestBtns />} />
+      </Route>
     </Routes>
   )
 }
 
 export default TestG
+
+const routeArr = [
+  { path: '/modal/review_posting', title: 'review_posting' },
+  { path: '/modal/review_detail', title: 'review_detail' },
+  { path: '/modal/date_picker', title: 'date_picker' },
+  { path: '/modal/choosing_lecture', title: 'choosing_lecture' },
+]
+
+function ModalTestBtns() {
+  const { openModal } = useModal()
+  return (
+    <>
+      {routeArr.map((el) => (
+        <button key={el.path} onClick={() => openModal(el.path, el.title)} />
+      ))}
+    </>
+  )
+}

--- a/src/test/TestModal.tsx
+++ b/src/test/TestModal.tsx
@@ -1,0 +1,26 @@
+import { BasicButton } from '@/components/basicComponents/BasicButton/BasicButton'
+
+import { useModal } from '@/hooks/useModal'
+
+const routeArr = [
+  { path: '/modal/review_posting', title: 'review_posting' },
+  { path: '/modal/review_detail', title: 'review_detail' },
+  { path: '/modal/date_picker', title: 'date_picker' },
+  { path: '/modal/choosing_lecture', title: 'choosing_lecture' },
+]
+
+function TestModal() {
+  const { openModal } = useModal()
+
+  return (
+    <>
+      {routeArr.map((el) => (
+        <BasicButton key={el.path} onClick={() => openModal(el.path, el.title)}>
+          {el.title}
+        </BasicButton>
+      ))}
+    </>
+  )
+}
+
+export default TestModal


### PR DESCRIPTION
## 💡 개요

- 모달 관련한 로직들 전반적으로 개편

## 📝 상세 내용

- 기존 useLocation 의존적이던 prevPath, title, subTitle을 스토어 의존적으로 변경
- 커스텀 훅에 닫기 로직을 추가하여 닫기를 통한 이동 완료시 스토어 초기화
- BasicModal 닫기 로직을 커스텀 훅을 통해 실행되도록 변경
- 각 세부적인 모달 컴포넌트에서 스토어를 직접 참조하는 닫기 로직이 있었으나, 커스텀 훅을 사용하도록 변경

<br>

- 모달 테스트 페이지를 추가하여 이후에 모달이 추가되더라도 쉽게 테스트 가능하도록 조치함

## ✅ 체크리스트

- [x] 코드에 불필요한 console.log 제거
- [x] lint 검사 통과
- [ ] 테스트 통과
- [ ] 관련 문서/README 업데이트

## 🔗 관련 이슈

- close #9 #27 
