### PR TITLE
fix:nav bar 수정

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -33,3 +33,13 @@
   --color-danger-600: #dc2626;
   --color-danger-800: #991b1b;
 }
+
+.center-center {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.nav-links {
+  @apply hover:text-primary-600 text-base font-normal text-gray-700 transition-colors;
+}

--- a/src/components/basicComponents/input/BasicInput.tsx
+++ b/src/components/basicComponents/input/BasicInput.tsx
@@ -36,7 +36,7 @@ interface InputProps extends React.InputHTMLAttributes<HTMLInputElement> {
 }
 
 // 인풋 컴포넌트
-export function InputField({
+export function BasicInput({
   status = 'default',
   label,
   errorMessage,

--- a/src/components/basicComponents/input/BasicInput.tsx
+++ b/src/components/basicComponents/input/BasicInput.tsx
@@ -4,25 +4,25 @@ import clsx from 'clsx'
 // disabled일때 ph는 투명도 50%
 const INPUT_COLORS = {
   default: {
-    bg: 'bg-gray-50',
+    bg: 'bg-white',
     bd: 'border-gray-300',
     ph: 'placeholder-gray-400',
   },
   focus: {
-    bg: 'bg-gray-50',
-    bd: 'border-primary-400',
+    bg: 'bg-white',
+    bd: 'border-primary-500',
     ph: 'placeholder-gray-400',
   },
   error: {
-    bg: 'bg-gray-50',
-    bd: 'border-danger-400',
+    bg: 'bg-white',
+    bd: 'border-danger-100',
     ph: 'placeholder-gray-400',
     msg: 'text-danger-600',
   },
   disabled: {
-    bg: 'bg-gray-100',
+    bg: 'bg-gray-50/50',
     bd: 'border-gray-300',
-    ph: 'placeholder-gray-400/50',
+    ph: 'placeholder-black/50',
   },
 }
 
@@ -50,7 +50,7 @@ export function BasicInput({
     color.bd,
     color.ph,
     {
-      'cursor-not-allowed text-gray-400': status === 'disabled',
+      'cursor-not-allowed text-black/50': status === 'disabled',
       'focus:border-primary-500 focus:ring-1 focus:ring-primary-300':
         status === 'focus',
     }

--- a/src/components/navBar/NavBar.tsx
+++ b/src/components/navBar/NavBar.tsx
@@ -25,10 +25,10 @@ export default function NavbarLayout() {
 function Logo() {
   return (
     <NavLink to="/" className="flex items-center space-x-2">
-      <div className="flex h-8 w-8 items-center justify-center rounded-lg bg-yellow-400 font-semibold text-white">
+      <div className="bg-primary-400 flex h-8 w-8 items-center justify-center rounded-lg font-semibold text-white">
         S
       </div>
-      <span className="text-xl font-semibold text-yellow-600">StudyHub</span>
+      <span className="text-primary-600 text-xl font-semibold">StudyHub</span>
     </NavLink>
   )
 }
@@ -47,7 +47,7 @@ function Links() {
           key={link.path}
           to={link.path}
           className={({ isActive }) =>
-            `nav-links ${isActive ? 'text-yellow-600' : ''}`
+            `nav-links ${isActive ? 'text-primary-600' : ''}`
           }
         >
           {link.label}

--- a/src/components/navBar/NavBar.tsx
+++ b/src/components/navBar/NavBar.tsx
@@ -8,7 +8,7 @@ export default function NavbarLayout() {
         <div className="flex h-full items-center justify-between px-8">
           <Logo />
 
-          <div className="flex items-center space-x-6 text-sm font-medium">
+          <div className="flex items-center space-x-8">
             <Links />
             <UserMenu />
           </div>
@@ -47,11 +47,7 @@ function Links() {
           key={link.path}
           to={link.path}
           className={({ isActive }) =>
-            `pb-1 transition-colors ${
-              isActive
-                ? 'text-yellow-600'
-                : 'text-gray-700 hover:text-yellow-600'
-            }`
+            `nav-links ${isActive ? 'text-yellow-600' : ''}`
           }
         >
           {link.label}

--- a/src/components/navBar/NavBar.tsx
+++ b/src/components/navBar/NavBar.tsx
@@ -4,7 +4,7 @@ import { UserMenu } from './userMenu/UserMenu'
 export default function NavbarLayout() {
   return (
     <div className="flex min-h-screen flex-col">
-      <nav className="fixed top-0 right-0 left-0 z-50 h-[65px] bg-white/90 px-20 backdrop-blur-sm">
+      <nav className="fixed top-0 right-0 left-0 z-50 h-[65px] border-b border-gray-200 bg-white px-20">
         <div className="flex h-full items-center justify-between px-8">
           <Logo />
 
@@ -15,7 +15,7 @@ export default function NavbarLayout() {
         </div>
       </nav>
 
-      <main className="mt-[65px] flex w-full flex-1 items-center justify-center bg-gray-50">
+      <main className="mt-[65px] flex w-full flex-1 items-center justify-center bg-white">
         <Outlet />
       </main>
     </div>

--- a/src/components/navBar/userMenu/LoginedMenu.tsx
+++ b/src/components/navBar/userMenu/LoginedMenu.tsx
@@ -54,10 +54,7 @@ export function LoginedMenu() {
 
   return (
     <div className="relative flex items-center space-x-4">
-      <button
-        onClick={handleNoti}
-        className="relative text-gray-700 transition-colors hover:text-yellow-600"
-      >
+      <button onClick={handleNoti} className="nav-links relative">
         <Bell size={22} />
         <span className="absolute -top-1 -right-1 flex h-4 w-4 items-center justify-center rounded-full bg-red-500 text-[10px] font-bold text-white">
           {notiCount}
@@ -67,10 +64,10 @@ export function LoginedMenu() {
       <div className="relative" ref={menuRef}>
         <button
           onClick={handlePanel}
-          className="group flex cursor-pointer items-center space-x-2 rounded-lg px-2 py-1 transition-colors duration-200 ease-in-out hover:bg-yellow-50"
+          className="group hover:bg-primary-50 flex cursor-pointer items-center space-x-2 rounded-lg px-2 py-1 transition-colors duration-200 ease-in-out"
         >
-          <div className="center-center h-8 w-8 rounded-full bg-yellow-100 transition-colors duration-200 group-hover:bg-yellow-200">
-            <User className="text-yellow-600" size={18} />
+          <div className="center-center bg-primary-100 group-hover:bg-primary-200 h-8 w-8 rounded-full transition-colors duration-200">
+            <User className="text-primary-600" size={18} />
           </div>
           <span className="text-sm font-medium text-gray-700">김개발</span>
         </button>
@@ -96,7 +93,7 @@ function UserPanel({ onClose }: { onClose: () => void }) {
 
       <NavLink
         to="/logout"
-        className="flex flex-1 items-center space-x-2 px-4 text-sm text-red-600 transition-colors hover:bg-gray-50"
+        className="text-danger-600 flex flex-1 items-center space-x-2 px-4 text-sm transition-colors hover:bg-gray-50"
         onClick={() => onClose()}
       >
         <LogOut size={16} />

--- a/src/components/navBar/userMenu/LoginedMenu.tsx
+++ b/src/components/navBar/userMenu/LoginedMenu.tsx
@@ -67,9 +67,11 @@ export function LoginedMenu() {
       <div className="relative" ref={menuRef}>
         <button
           onClick={handlePanel}
-          className="flex items-center space-x-1 rounded-full bg-yellow-100 px-2 py-1 transition-colors hover:bg-yellow-200"
+          className="group flex cursor-pointer items-center space-x-2 rounded-lg px-2 py-1 transition-colors duration-200 ease-in-out hover:bg-yellow-50"
         >
-          <User className="text-yellow-600" size={18} />
+          <div className="center-center h-8 w-8 rounded-full bg-yellow-100 transition-colors duration-200 group-hover:bg-yellow-200">
+            <User className="text-yellow-600" size={18} />
+          </div>
           <span className="text-sm font-medium text-gray-700">김개발</span>
         </button>
 

--- a/src/components/navBar/userMenu/LogoutedMenu.tsx
+++ b/src/components/navBar/userMenu/LogoutedMenu.tsx
@@ -3,12 +3,12 @@ import { NavLink } from 'react-router'
 export function LogoutedMenu() {
   return (
     <>
-      <NavLink to="/login" className="hover:text-yellow-600">
+      <NavLink to="/login" className="nav-links">
         로그인
       </NavLink>
       <NavLink
         to="/signup"
-        className="rounded-lg bg-yellow-400 px-4 py-2 text-white hover:bg-yellow-500"
+        className="bg-primary-500 hover:bg-primary-600 rounded-lg px-4 py-2 text-white transition-colors"
       >
         회원가입
       </NavLink>{' '}

--- a/src/components/navBar/userMenu/UserMenu.tsx
+++ b/src/components/navBar/userMenu/UserMenu.tsx
@@ -3,6 +3,6 @@ import { LogoutedMenu } from './LogoutedMenu'
 
 export function UserMenu() {
   // 로그인 확인 로직 필요
-  const isLogined = false
+  const isLogined = true
   return isLogined ? <LoginedMenu /> : <LogoutedMenu />
 }

--- a/src/components/navBar/userMenu/UserMenu.tsx
+++ b/src/components/navBar/userMenu/UserMenu.tsx
@@ -3,6 +3,6 @@ import { LogoutedMenu } from './LogoutedMenu'
 
 export function UserMenu() {
   // 로그인 확인 로직 필요
-  const isLogined = true
+  const isLogined = false
   return isLogined ? <LoginedMenu /> : <LogoutedMenu />
 }


### PR DESCRIPTION
## 💡 개요

- 링크들 폰트 및 스타일 통일
  - 기존에 "강의목록/스터디그룹/구인공고" 와 "로그인/회원가입" 폰트가 맞지않아 이점을 수정함
- 프로필 테두리가 사용자 명까지 덮어져 있었으나, 레이아웃을 변경하여 확실히 프로필 이미지만 배경색상을 띄도록 변경함
  - 전
![Honeycam 2025-10-17 16-18-591](https://github.com/user-attachments/assets/96161d4a-1576-42ee-afbc-fee8fbc719c3)
  - 후
<img width="166" height="58" alt="image" src="https://github.com/user-attachments/assets/acb1b82b-4dff-443a-a49c-f83aef933ba2" />


## 📝 상세 내용

- app.css에 스타일 통일용 커스텀 클래스 네임을 추가함

## ✅ 체크리스트

- [x] 코드에 불필요한 console.log 제거
- [x] lint 검사 통과
- [ ] 테스트 통과
- [ ] 관련 문서/README 업데이트

## 🔗 관련 이슈

- close #4 
