### PR TITLE
fix:modal 의존성 배열 수정

### DIFF
--- a/src/components/basicComponents/basicModal/BasicModal.tsx
+++ b/src/components/basicComponents/basicModal/BasicModal.tsx
@@ -36,19 +36,17 @@ export default function BasicModal() {
 
   // 무한 랜더링 방지 및 린트 회피용 ref
   const setModalOpenRef = useRef(setModalState)
-  const isModalOpenRef = useRef(isModalOpen)
   const closeModalRef = useRef(closeModal)
 
   // location이 변경될 때마다 모달 상태 확인
   useEffect(() => {
     const smorc = setModalOpenRef.current
-    const imorc = isModalOpenRef.current
 
     const isModalRoute = location.pathname.startsWith('/modal')
-    if (isModalRoute && !imorc) {
+    if (isModalRoute && !isModalOpen) {
       smorc({ isModalOpen: true })
       document.body.style.overflow = 'hidden'
-    } else if (!isModalRoute && imorc) {
+    } else if (!isModalRoute && isModalOpen) {
       smorc({ isModalOpen: false })
       document.body.style.overflow = 'unset'
     }
@@ -64,7 +62,7 @@ export default function BasicModal() {
       smorc({ isModalOpen: false })
       document.body.style.overflow = 'unset'
     }
-  }, [location.pathname])
+  }, [location.pathname, isModalOpen])
 
   // esc 누를시 이전 경로로 이동
   useEffect(() => {


### PR DESCRIPTION
## 💡 개요

- 베이직 모달의 의존성 배열 수정

<img width="1098" height="821" alt="image" src="https://github.com/user-attachments/assets/8ae057ee-d515-4901-843f-a19ba939cddd" />

동작 확인

## 📝 상세 내용

- 기존에 ref 참조로 실행하여 isModalOpen에 의해 리랜더링이 일어나지 않도록 막혀 있었으나, 스토어의 상태가 비동기로 업데이트 되는 특성상 경로이동 > 늦은 스토어 업데이트 > isModalOpen && (컴포넌트) 에서 false가 나옴 > 빈화면 출력 이라는 시나리오가 가능해 ref를 떼고 직접 의존성 배열에 isModalOpen 변수를 넣어 반드시 이 값에 따라 리랜더링이 발생하도록 조치함

## ✅ 체크리스트

- [x] 코드에 불필요한 console.log 제거
- [x] lint 검사 통과
- [ ] 테스트 통과
- [ ] 관련 문서/README 업데이트

## 🔗 관련 이슈

- close #9 
