### PR TITLE
fix/9 - [모달] 불필요한 변수 삭제 및 모달 헤더에서 직접 스토어 구독하도록 수정

### DIFF
--- a/src/components/basicComponents/basicModal/BasicModal.tsx
+++ b/src/components/basicComponents/basicModal/BasicModal.tsx
@@ -31,9 +31,6 @@ export default function BasicModal() {
   const isModalOpen = storeModalOpen((state) => state.modalState.isModalOpen)
   const setModalState = storeModalOpen((state) => state.setModalState)
 
-  // navigate를 통해 들어온 값들
-  const { title, subTitle } = storeModalOpen().modalState
-
   // 무한 랜더링 방지 및 린트 회피용 ref
   const setModalOpenRef = useRef(setModalState)
   const closeModalRef = useRef(closeModal)
@@ -121,10 +118,8 @@ export default function BasicModal() {
             transition={{ type: 'spring', stiffness: 280, damping: 25 }}
             onClick={(e) => e.stopPropagation()}
           >
-            <div>
-              <ModalHeader title={title} subTitle={subTitle} />
-              <Outlet />
-            </div>
+            <ModalHeader />
+            <Outlet />
           </motion.div>
         </motion.div>
       )}

--- a/src/components/modal/ModalHeader.tsx
+++ b/src/components/modal/ModalHeader.tsx
@@ -1,13 +1,10 @@
 import { useModal } from '@/hooks/useModal'
+import { storeModalOpen } from '@/store/storeModalOpen'
 import { X } from 'lucide-react'
 
-type ModalHeaderProps = {
-  title: string
-  subTitle?: string | null
-}
-
-const ModalHeader = ({ title, subTitle = null }: ModalHeaderProps) => {
+const ModalHeader = () => {
   const { closeModal } = useModal()
+  const { title, subTitle } = storeModalOpen().modalState
 
   const handleClickCancel = (e: React.MouseEvent) => {
     e.preventDefault()


### PR DESCRIPTION
## 💡 개요

- 멘토링 때 피드백 받았던대로, 불필요한 프롭스를 제거하고 모달 헤더에서 직접 스토어 상태를 구독하도록 변경
- **로직상에 차이는 없으니 모달 작업중 반복적으로 pull 받을 필요는 없음**

## ✅ 체크리스트

- [x] 코드에 불필요한 console.log 제거
- [x] lint 검사 통과
- [ ] 테스트 통과
- [ ] 관련 문서/README 업데이트

## 🔗 관련 이슈

- close #9 
