### PR TITLE
fix/9 - [모달] useModal, basicModal에서 동시에 isModalOpen 참조하던 문제 해결

### DIFF
--- a/src/components/basicComponents/basicModal/BasicModal.tsx
+++ b/src/components/basicComponents/basicModal/BasicModal.tsx
@@ -28,7 +28,7 @@ export default function BasicModal() {
   const { closeModal } = useModal()
 
   // Zustand store
-  const isModalOpen = storeModalOpen((state) => state.modalState.isModalOpen)
+  const { isModalOpen, isClosing } = storeModalOpen((state) => state.modalState)
   const setModalState = storeModalOpen((state) => state.setModalState)
 
   // 무한 랜더링 방지 및 린트 회피용 ref
@@ -38,9 +38,9 @@ export default function BasicModal() {
   // location이 변경될 때마다 모달 상태 확인
   useEffect(() => {
     const smorc = setModalOpenRef.current
-
     const isModalRoute = location.pathname.startsWith('/modal')
-    if (isModalRoute && !isModalOpen) {
+
+    if (isModalRoute && !isModalOpen && !isClosing) {
       smorc({ isModalOpen: true })
       document.body.style.overflow = 'hidden'
     } else if (!isModalRoute && isModalOpen) {
@@ -56,10 +56,10 @@ export default function BasicModal() {
     // 위의 else if는 경로 이동에 따른 모달 상태관리
     // 아래의 return 클린업 함수는 비정상 종료 대응용 안전장치
     return () => {
-      smorc({ isModalOpen: false })
       document.body.style.overflow = 'unset'
     }
-  }, [location.pathname, isModalOpen])
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [location.pathname])
 
   // esc 누를시 이전 경로로 이동
   useEffect(() => {

--- a/src/hooks/useModal.ts
+++ b/src/hooks/useModal.ts
@@ -1,5 +1,5 @@
 import { storeModalOpen } from '@/store/storeModalOpen'
-import { useEffect, useRef } from 'react'
+import { useEffect } from 'react'
 import { useNavigate, useLocation } from 'react-router'
 
 /**
@@ -20,17 +20,18 @@ import { useNavigate, useLocation } from 'react-router'
 export function useModal() {
   const navigate = useNavigate()
   const location = useLocation()
-  const isClosingRef = useRef(false)
+
+  const { modalState, setModalState, clearModal } = storeModalOpen()
 
   // 모달 열기
   const openModal = (modalPath: string, title: string, subTitle?: string) => {
     const currentPath = location.pathname
     navigate(modalPath)
-    storeModalOpen.getState().setModalState({
-      isModalOpen: true,
+    setModalState({
       prevPath: currentPath,
       title: title,
       subTitle: subTitle,
+      isClosing: false,
     })
   }
 
@@ -45,8 +46,7 @@ export function useModal() {
     subTitle?: string
   ) => {
     navigate(modalPath)
-    storeModalOpen.getState().setModalState({
-      isModalOpen: true,
+    setModalState({
       title: title,
       subTitle: subTitle,
     })
@@ -56,20 +56,16 @@ export function useModal() {
   const closeModal = () => {
     const { prevPath } = storeModalOpen.getState().modalState
     if (prevPath) {
-      isClosingRef.current = true
+      setModalState({ isClosing: true })
       navigate(prevPath, { replace: true })
     }
   }
 
-  // 모달 닫을때 상태 초기화
-  // 기존에 clearModal이 과도하게 실행되는 문제가 있었으나, isClosingRef 참조형으로 변경하여 해결
   useEffect(() => {
-    const { modalState, clearModal } = storeModalOpen.getState()
-
-    if (isClosingRef.current && location.pathname === modalState.prevPath) {
+    if (modalState.isClosing && location.pathname === modalState.prevPath) {
       clearModal()
-      isClosingRef.current = false
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [location.pathname])
 
   return { openModal, closeModal, modalToModal } as const

--- a/src/store/storeModalOpen.ts
+++ b/src/store/storeModalOpen.ts
@@ -5,6 +5,7 @@ type ModalState = {
   prevPath: string
   title: string
   subTitle?: string
+  isClosing: boolean
 }
 interface storeModalState {
   modalState: ModalState
@@ -18,6 +19,7 @@ const initState: ModalState = {
   prevPath: '',
   title: '',
   subTitle: '',
+  isClosing: false,
 }
 
 export const storeModalOpen = create<storeModalState>((set) => ({


### PR DESCRIPTION
## 💡 개요

- BasicModal과 useModal에서 동시에 isModalOpen을 수정하던 문제 해결

## 📝 상세 내용

- BasicModal에서 전적으로 경로에 따라 isModalOpen을 관리하고, useModal에서는 isModalOpen을 참조하던 것을 제외함

## ✅ 체크리스트

- [x] 코드에 불필요한 console.log 제거
- [x] lint 검사 통과
- [ ] 테스트 통과
- [ ] 관련 문서/README 업데이트

## 🔗 관련 이슈

- close #9 
