### PR TITLE
Feat/60 detail study schedule UI

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@tanstack/react-query": "^5.80.7",
         "axios": "^1.10.0",
         "clsx": "^2.1.1",
+        "dayjs": "^1.11.18",
         "framer-motion": "^12.23.24",
         "lodash": "^4.17.21",
         "lucide-react": "^0.515.0",
@@ -2593,6 +2594,12 @@
       "version": "4.1.0-0",
       "resolved": "https://registry.npmjs.org/date-fns-jalali/-/date-fns-jalali-4.1.0-0.tgz",
       "integrity": "sha512-hTIP/z+t+qKwBDcmmsnmjWTduxCg+5KfdqWQvb2X/8C9+knYY6epN/pfxdDuyVlSVeFz0sM5eEfwIUQ70U4ckg==",
+      "license": "MIT"
+    },
+    "node_modules/dayjs": {
+      "version": "1.11.18",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.18.tgz",
+      "integrity": "sha512-zFBQ7WFRvVRhKcWoUh+ZA1g2HVgUbsZm9sbddh8EC5iv93sui8DVVz1Npvz+r6meo9VKfa8NyLWBsQK1VvIKPA==",
       "license": "MIT"
     },
     "node_modules/debug": {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@tanstack/react-query": "^5.80.7",
     "axios": "^1.10.0",
     "clsx": "^2.1.1",
+    "dayjs": "^1.11.18",
     "framer-motion": "^12.23.24",
     "lodash": "^4.17.21",
     "lucide-react": "^0.515.0",

--- a/src/assets/dummyData/dummySchedule.ts
+++ b/src/assets/dummyData/dummySchedule.ts
@@ -1,0 +1,15 @@
+export const dummySchedule = {
+  id: 1,
+  title: 'React Hooks 심화학습',
+  goal: 'useState, useEffect,useContext 등 주요 Hook들의 동작 원리와 최적화 방법 학습',
+  date: '2024-07-01',
+  startTime: '10:00',
+  endTime: '12:00',
+  create_at: '2024-06-20T10:00:00Z',
+  participants: [
+    { id: 1, nickname: '김개발', is_leader: true },
+    { id: 2, nickname: '박리엑트', is_leader: false },
+    { id: 4, nickname: '최자바', is_leader: false },
+    { id: 6, nickname: '오컴포넌트', is_leader: false },
+  ],
+}

--- a/src/components/modal/ModalHeader.tsx
+++ b/src/components/modal/ModalHeader.tsx
@@ -12,7 +12,7 @@ const ModalHeader = () => {
   }
 
   return (
-    <header className="flex justify-between border-b border-gray-300 p-6 text-gray-900">
+    <header className="flex justify-between border-b border-gray-200 p-6 text-gray-900">
       <div className="flex flex-col">
         <h1 className="text-lg font-semibold text-gray-900">{title}</h1>
         <h2 className="text-sm font-normal text-gray-500">{subTitle}</h2>

--- a/src/components/modal/detailSchedule/DetailScheduleInfo.tsx
+++ b/src/components/modal/detailSchedule/DetailScheduleInfo.tsx
@@ -1,7 +1,12 @@
 import { dummySchedule } from '@/assets/dummyData/dummySchedule'
 import { Calendar, Clock3 } from 'lucide-react'
+import dayjs from '@/lib/dayjs'
 
 const DetailScheduleInfo = () => {
+  const formattedScheduleDate = dayjs(dummySchedule.date)
+    .format('LLLL')
+    .slice(0, 15)
+
   return (
     <section className="flex flex-col gap-6">
       <h3 className="text-lg">{dummySchedule.title}</h3>
@@ -14,7 +19,7 @@ const DetailScheduleInfo = () => {
           <h4 className="text-sm font-medium text-gray-700">스터디 날짜</h4>
           <p className="flex items-center gap-2">
             <Calendar size={16} className="text-gray-400" />{' '}
-            {dummySchedule.date}
+            {formattedScheduleDate}
           </p>
         </div>
         <div className="flex flex-col gap-2">

--- a/src/components/modal/detailSchedule/DetailScheduleInfo.tsx
+++ b/src/components/modal/detailSchedule/DetailScheduleInfo.tsx
@@ -1,0 +1,32 @@
+import { dummySchedule } from '@/assets/dummyData/dummySchedule'
+import { Calendar, Clock3 } from 'lucide-react'
+
+const DetailScheduleInfo = () => {
+  return (
+    <section className="flex flex-col gap-6">
+      <h3 className="text-lg">{dummySchedule.title}</h3>
+      <div className="flex flex-col gap-2">
+        <h4 className="text-sm font-medium text-gray-700">스터디 목표</h4>
+        <p className="rounded-lg bg-gray-50 p-4">{dummySchedule.goal}</p>
+      </div>
+      <div className="grid grid-cols-2 gap-4">
+        <div className="flex flex-col gap-2">
+          <h4 className="text-sm font-medium text-gray-700">스터디 날짜</h4>
+          <p className="flex items-center gap-2">
+            <Calendar size={16} className="text-gray-400" />{' '}
+            {dummySchedule.date}
+          </p>
+        </div>
+        <div className="flex flex-col gap-2">
+          <h4 className="text-sm font-medium text-gray-700">스터디 날짜</h4>
+          <p className="flex items-center gap-2">
+            <Clock3 size={16} className="text-gray-400" />{' '}
+            {dummySchedule.startTime} ~ {dummySchedule.endTime}
+          </p>
+        </div>
+      </div>
+    </section>
+  )
+}
+
+export default DetailScheduleInfo

--- a/src/components/modal/detailSchedule/DetailScheduleModal.tsx
+++ b/src/components/modal/detailSchedule/DetailScheduleModal.tsx
@@ -1,7 +1,8 @@
 import { dummySchedule } from '@/assets/dummyData/dummySchedule'
 import { BasicButton } from '@/components/basicComponents/BasicButton/BasicButton'
 import { useModal } from '@/hooks/useModal'
-import { Calendar, Clock3, User } from 'lucide-react'
+import DetailScheduleInfo from './DetailScheduleInfo'
+import DetailScheduleSelectedParticipants from './DetailScheduleSelectedParticipants'
 
 const DetailScheduleModal = () => {
   const { closeModal } = useModal()
@@ -14,52 +15,10 @@ const DetailScheduleModal = () => {
   return (
     <div className="w-[672px] text-gray-900">
       <main className="flex flex-col gap-6 p-6">
-        <section>
-          <h3 className="text-lg">{dummySchedule.title}</h3>
-          <div className="flex flex-col gap-2">
-            <h4 className="text-sm font-medium text-gray-700">스터디 목표</h4>
-            <p className="rounded-lg bg-gray-50 p-4">{dummySchedule.goal}</p>
-          </div>
-          <div className="grid grid-cols-2 gap-4">
-            <div className="flex flex-col gap-2">
-              <h4 className="text-sm font-medium text-gray-700">스터디 날짜</h4>
-              <p className="flex items-center gap-2">
-                <Calendar size={16} className="text-gray-400" />{' '}
-                {dummySchedule.date}
-              </p>
-            </div>
-            <div className="flex flex-col gap-2">
-              <h4 className="text-sm font-medium text-gray-700">스터디 날짜</h4>
-              <p className="flex items-center gap-2">
-                <Clock3 size={16} className="text-gray-400" />{' '}
-                {dummySchedule.startTime} ~ {dummySchedule.endTime}
-              </p>
-            </div>
-          </div>
-        </section>
-        <section>
-          <h4>참여자 목록 {`(${dummySchedule.participants.length}명)`}</h4>
-          <ul className="flex max-h-48 flex-col gap-2 overflow-y-auto rounded-lg border border-gray-200 p-4">
-            {dummySchedule.participants.map((participant) => (
-              <li
-                key={participant.id}
-                className="flex items-center gap-3 text-sm"
-              >
-                <div className="center-center bg-primary-100 h-8 w-8 rounded-full">
-                  <User className="text-primary-600" size={18} />
-                </div>
-                {participant.nickname}
-                {participant.is_leader && (
-                  <span className="bg-primary-100 text-primary-800 rounded-sm px-2 py-1 text-xs">
-                    리더
-                  </span>
-                )}
-              </li>
-            ))}
-          </ul>
-        </section>
+        <DetailScheduleInfo />
+        <DetailScheduleSelectedParticipants />
       </main>
-      <footer className="flex w-full items-center justify-between gap-3 border-t border-gray-300 p-6">
+      <footer className="flex w-full items-center justify-between gap-3 border-t border-gray-200 p-6">
         <span className="text-xs text-gray-500">
           생성일: {dummySchedule.create_at}
         </span>

--- a/src/components/modal/detailSchedule/DetailScheduleModal.tsx
+++ b/src/components/modal/detailSchedule/DetailScheduleModal.tsx
@@ -3,11 +3,13 @@ import { BasicButton } from '@/components/basicComponents/BasicButton/BasicButto
 import { useModal } from '@/hooks/useModal'
 import DetailScheduleInfo from './DetailScheduleInfo'
 import DetailScheduleSelectedParticipants from './DetailScheduleSelectedParticipants'
-import { formattedReviewUpdatedDate } from '@/utils/formattedDate'
+import dayjs from '@/lib/dayjs'
 
 const DetailScheduleModal = () => {
   const { modalToModal } = useModal()
-  const formattedDate = formattedReviewUpdatedDate(dummySchedule.create_at)
+  const formattedCreatedScheduleDate = dayjs(dummySchedule.create_at).format(
+    'LLL'
+  )
 
   const handleClickEdit = (e: React.MouseEvent) => {
     e.preventDefault()
@@ -21,7 +23,9 @@ const DetailScheduleModal = () => {
         <DetailScheduleSelectedParticipants />
       </main>
       <footer className="flex w-full items-center justify-between gap-3 border-t border-gray-200 p-6">
-        <span className="text-xs text-gray-500">생성일: {formattedDate}</span>
+        <span className="text-xs text-gray-500">
+          생성일: {formattedCreatedScheduleDate}
+        </span>
         <div className="flex gap-3">
           <BasicButton type="primary" size="medium" onClick={handleClickEdit}>
             수정

--- a/src/components/modal/detailSchedule/DetailScheduleModal.tsx
+++ b/src/components/modal/detailSchedule/DetailScheduleModal.tsx
@@ -1,0 +1,79 @@
+import { dummySchedule } from '@/assets/dummyData/dummySchedule'
+import { BasicButton } from '@/components/basicComponents/BasicButton/BasicButton'
+import { useModal } from '@/hooks/useModal'
+import { Calendar, Clock3, User } from 'lucide-react'
+
+const DetailScheduleModal = () => {
+  const { closeModal } = useModal()
+
+  const handleClickCancel = (e: React.MouseEvent) => {
+    e.preventDefault()
+    closeModal()
+  }
+
+  return (
+    <div className="w-[672px] text-gray-900">
+      <main className="flex flex-col gap-6 p-6">
+        <section>
+          <h3 className="text-lg">{dummySchedule.title}</h3>
+          <div className="flex flex-col gap-2">
+            <h4 className="text-sm font-medium text-gray-700">스터디 목표</h4>
+            <p className="rounded-lg bg-gray-50 p-4">{dummySchedule.goal}</p>
+          </div>
+          <div className="grid grid-cols-2 gap-4">
+            <div className="flex flex-col gap-2">
+              <h4 className="text-sm font-medium text-gray-700">스터디 날짜</h4>
+              <p className="flex items-center gap-2">
+                <Calendar size={16} className="text-gray-400" />{' '}
+                {dummySchedule.date}
+              </p>
+            </div>
+            <div className="flex flex-col gap-2">
+              <h4 className="text-sm font-medium text-gray-700">스터디 날짜</h4>
+              <p className="flex items-center gap-2">
+                <Clock3 size={16} className="text-gray-400" />{' '}
+                {dummySchedule.startTime} ~ {dummySchedule.endTime}
+              </p>
+            </div>
+          </div>
+        </section>
+        <section>
+          <h4>참여자 목록 {`(${dummySchedule.participants.length}명)`}</h4>
+          <ul className="flex max-h-48 flex-col gap-2 overflow-y-auto rounded-lg border border-gray-200 p-4">
+            {dummySchedule.participants.map((participant) => (
+              <li
+                key={participant.id}
+                className="flex items-center gap-3 text-sm"
+              >
+                <div className="center-center bg-primary-100 h-8 w-8 rounded-full">
+                  <User className="text-primary-600" size={18} />
+                </div>
+                {participant.nickname}
+                {participant.is_leader && (
+                  <span className="bg-primary-100 text-primary-800 rounded-sm px-2 py-1 text-xs">
+                    리더
+                  </span>
+                )}
+              </li>
+            ))}
+          </ul>
+        </section>
+      </main>
+      <footer className="flex w-full items-center justify-between gap-3 border-t border-gray-300 p-6">
+        <span className="text-xs text-gray-500">
+          생성일: {dummySchedule.create_at}
+        </span>
+        <div className="flex gap-3">
+          <BasicButton type="primary" size="medium" onClick={handleClickCancel}>
+            수정
+          </BasicButton>
+          <BasicButton type="danger" size="medium">
+            삭제
+          </BasicButton>
+        </div>
+      </footer>
+    </div>
+  )
+}
+
+export default DetailScheduleModal

--- a/src/components/modal/detailSchedule/DetailScheduleModal.tsx
+++ b/src/components/modal/detailSchedule/DetailScheduleModal.tsx
@@ -3,13 +3,15 @@ import { BasicButton } from '@/components/basicComponents/BasicButton/BasicButto
 import { useModal } from '@/hooks/useModal'
 import DetailScheduleInfo from './DetailScheduleInfo'
 import DetailScheduleSelectedParticipants from './DetailScheduleSelectedParticipants'
+import { formattedReviewUpdatedDate } from '@/utils/formattedDate'
 
 const DetailScheduleModal = () => {
-  const { closeModal } = useModal()
+  const { modalToModal } = useModal()
+  const formattedDate = formattedReviewUpdatedDate(dummySchedule.create_at)
 
-  const handleClickCancel = (e: React.MouseEvent) => {
+  const handleClickEdit = (e: React.MouseEvent) => {
     e.preventDefault()
-    closeModal()
+    modalToModal('/modal/add_schedule', '스케줄 수정')
   }
 
   return (
@@ -19,11 +21,9 @@ const DetailScheduleModal = () => {
         <DetailScheduleSelectedParticipants />
       </main>
       <footer className="flex w-full items-center justify-between gap-3 border-t border-gray-200 p-6">
-        <span className="text-xs text-gray-500">
-          생성일: {dummySchedule.create_at}
-        </span>
+        <span className="text-xs text-gray-500">생성일: {formattedDate}</span>
         <div className="flex gap-3">
-          <BasicButton type="primary" size="medium" onClick={handleClickCancel}>
+          <BasicButton type="primary" size="medium" onClick={handleClickEdit}>
             수정
           </BasicButton>
           <BasicButton type="danger" size="medium">

--- a/src/components/modal/detailSchedule/DetailScheduleSelectedParticipants.tsx
+++ b/src/components/modal/detailSchedule/DetailScheduleSelectedParticipants.tsx
@@ -1,0 +1,40 @@
+import { dummySchedule } from '@/assets/dummyData/dummySchedule'
+import { User } from 'lucide-react'
+
+const DetailScheduleSelectedParticipants = () => {
+  const { participants } = dummySchedule
+
+  const leader = participants.find((participant) => participant.is_leader)
+  const others = participants.filter((participant) => !participant.is_leader)
+
+  return (
+    <section className="flex flex-col gap-2">
+      <h4 className="text-sm font-medium text-gray-700">
+        참여자 목록 {`(${dummySchedule.participants.length}명)`}
+      </h4>
+      <ul className="flex max-h-48 flex-col gap-2 overflow-y-auto rounded-lg border border-gray-200 p-4">
+        {leader && (
+          <li className="flex items-center gap-3 text-sm">
+            <div className="center-center bg-primary-100 h-8 w-8 rounded-full">
+              <User className="text-primary-600" size={18} />
+            </div>
+            {leader.nickname}
+            <span className="bg-primary-100 text-primary-800 rounded-sm px-2 py-1 text-xs">
+              리더
+            </span>
+          </li>
+        )}
+        {others.map((participant) => (
+          <li key={participant.id} className="flex items-center gap-3 text-sm">
+            <div className="center-center bg-primary-100 h-8 w-8 rounded-full">
+              <User className="text-primary-600" size={18} />
+            </div>
+            {participant.nickname}
+          </li>
+        ))}
+      </ul>
+    </section>
+  )
+}
+
+export default DetailScheduleSelectedParticipants

--- a/src/components/modal/schedule/ScheduleModal.tsx
+++ b/src/components/modal/schedule/ScheduleModal.tsx
@@ -31,7 +31,7 @@ const ScheduleModal = () => {
           setSelectedParticipants={setSelectedParticipants}
         />
       </main>
-      <footer className="flex w-full justify-end gap-3 border-t border-gray-300 p-6">
+      <footer className="flex w-full justify-end gap-3 border-t border-gray-200 p-6">
         <BasicButton type="outline" size="large" onClick={handleClickCancel}>
           취소
         </BasicButton>

--- a/src/lib/dayjs.ts
+++ b/src/lib/dayjs.ts
@@ -16,10 +16,11 @@ dayjs.locale('ko')
 
 export default dayjs
 
-// 프로젝트 어디서든 import dayjs from "경로/lib/dayjs" 로 쓰면 플러그인/한글 설정이 적용된 상태로 사용됩니다.
+// 사용 시 import dayjs from "@/lib/dayjs" -> 플러그인/한글 설정이 적용된 상태로 사용가능
+// * 경로에 '@/lib/dayjs'를 사용해야 함에 유의!! (자동 import 시 'dayjs'로만 들어오는 경우가 있음)
 
 // localizedFormat 사용 예시:
-// dayjs().format("L") -> 2025.09.07;
+// dayjs().format("L") -> 2025.09.07
 // dayjs().format("LL") -> 2025년 9월 7일
 // dayjs().format("LLL") -> 2025년 9월 7일 오후 3:45
 // dayjs().format("LLLL") -> 2025년 9월 7일 일요일 오후 3:45

--- a/src/lib/dayjs.ts
+++ b/src/lib/dayjs.ts
@@ -1,0 +1,25 @@
+// src/lib/dayjs.ts
+import dayjs from 'dayjs'
+import 'dayjs/locale/ko'
+import relativeTime from 'dayjs/plugin/relativeTime'
+import localizedFormat from 'dayjs/plugin/localizedFormat' // e.g. L, LL
+import isBetween from 'dayjs/plugin/isBetween'
+import isSameOrBefore from 'dayjs/plugin/isSameOrBefore'
+import isSameOrAfter from 'dayjs/plugin/isSameOrAfter'
+
+dayjs.extend(relativeTime)
+dayjs.extend(localizedFormat)
+dayjs.extend(isBetween)
+dayjs.extend(isSameOrBefore)
+dayjs.extend(isSameOrAfter)
+dayjs.locale('ko')
+
+export default dayjs
+
+// 프로젝트 어디서든 import dayjs from "경로/lib/dayjs" 로 쓰면 플러그인/한글 설정이 적용된 상태로 사용됩니다.
+
+// localizedFormat 사용 예시:
+// dayjs().format("L") -> 2025.09.07;
+// dayjs().format("LL") -> 2025년 9월 7일
+// dayjs().format("LLL") -> 2025년 9월 7일 오후 3:45
+// dayjs().format("LLLL") -> 2025년 9월 7일 일요일 오후 3:45

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -14,6 +14,7 @@ import TestModal from './test/TestModal'
 import ReviewDetailModal from './components/modal/reviewDetail/ReviewDetailModal'
 import LectureChoosingModal from './components/modal/lectureChoosing/LectureChoosingModal'
 import ScheduleModal from './components/modal/schedule/ScheduleModal'
+import DetailScheduleModal from './components/modal/detailSchedule/DetailScheduleModal'
 
 const router = createBrowserRouter([
   {
@@ -50,6 +51,10 @@ const router = createBrowserRouter([
           {
             path: '/modal/add_schedule',
             Component: ScheduleModal,
+          },
+          {
+            path: '/modal/schedule_detail',
+            Component: DetailScheduleModal,
           },
         ],
       },

--- a/src/test/TestH.tsx
+++ b/src/test/TestH.tsx
@@ -1,9 +1,9 @@
-import LectureChoosingModal from '@/components/modal/lectureChoosing/LectureChoosingModal'
+import DetailScheduleModal from '@/components/modal/detailSchedule/DetailScheduleModal'
 
 function TestH() {
   return (
     <div>
-      <LectureChoosingModal />
+      <DetailScheduleModal />
     </div>
   )
 }

--- a/src/test/TestModal.tsx
+++ b/src/test/TestModal.tsx
@@ -4,7 +4,7 @@ import { useModal } from '@/hooks/useModal'
 
 const routeArr = [
   { path: '/modal/add_schedule', title: '새 스케줄 추가' },
-  { path: '/modal/review_detail', title: 'review_detail' },
+  { path: '/modal/schedule_detail', title: '스케줄 상세' },
   { path: '/modal/date_picker', title: 'date_picker' },
   { path: '/modal/choosing_lecture', title: 'choosing_lecture' },
 ]


### PR DESCRIPTION
## 📌 제목

- Feat/60 detail study schedule UI

## 💡 개요

- 스터디 스케줄 상세보기 모달창 UI

## 📝 상세 내용

- 스케줄 상세 모달 UI 생성
- dayjs 라이브러리 설치 및 설정 (dayjs 자주 사용하는 포멧 사용법 작성)
- 수정 버튼 클릭 시 모달 이동 구현

## 화면

<img width="489" height="471" alt="image" src="https://github.com/user-attachments/assets/a29affd9-dbf4-4097-8d18-4b4cf3c38cad" />


## ✅ 체크리스트

- [x] 코드에 불필요한 console.log 제거
- [x] lint 검사 통과
- [ ] 테스트 통과
- [ ] 관련 문서/README 업데이트

## 🔗 관련 이슈

- close #60 
