### PR TITLE
Feat/63 edit schedule UI

### DIFF
--- a/src/assets/dummyData/dummySchedule.ts
+++ b/src/assets/dummyData/dummySchedule.ts
@@ -5,7 +5,7 @@ export const dummySchedule = {
   date: '2024-07-01',
   startTime: '10:00',
   endTime: '12:00',
-  create_at: '2024-06-20T10:00:00Z',
+  created_at: '2024-06-20T10:00:00Z',
   participants: [
     { id: 1, nickname: '김개발', is_leader: true },
     { id: 2, nickname: '박리엑트', is_leader: false },

--- a/src/components/modal/detailSchedule/DetailScheduleModal.tsx
+++ b/src/components/modal/detailSchedule/DetailScheduleModal.tsx
@@ -9,7 +9,7 @@ import { storeSchedule } from '@/store/storeSchedule'
 const DetailScheduleModal = () => {
   const { modalToModal } = useModal()
   const { setPreviousSchedule } = storeSchedule()
-  const formattedCreatedScheduleDate = dayjs(dummySchedule.create_at).format(
+  const formattedCreatedScheduleDate = dayjs(dummySchedule.created_at).format(
     'LLL'
   )
 

--- a/src/components/modal/detailSchedule/DetailScheduleModal.tsx
+++ b/src/components/modal/detailSchedule/DetailScheduleModal.tsx
@@ -5,8 +5,10 @@ import DetailScheduleInfo from './DetailScheduleInfo'
 import DetailScheduleSelectedParticipants from './DetailScheduleSelectedParticipants'
 import dayjs from '@/lib/dayjs'
 import { storeSchedule } from '@/store/storeSchedule'
+import { useParams } from 'react-router'
 
 const DetailScheduleModal = () => {
+  const params = useParams<{ id: string }>()
   const { modalToModal } = useModal()
   const { setPreviousSchedule, setIsEdit } = storeSchedule()
   const formattedCreatedScheduleDate = dayjs(dummySchedule.created_at).format(
@@ -16,7 +18,7 @@ const DetailScheduleModal = () => {
   const handleClickEdit = () => {
     setPreviousSchedule(dummySchedule)
     setIsEdit(true)
-    modalToModal('/modal/edit_schedule', '스케줄 수정')
+    modalToModal(`/modal/edit_schedule/${params.id}`, '스케줄 수정')
   }
 
   return (

--- a/src/components/modal/detailSchedule/DetailScheduleModal.tsx
+++ b/src/components/modal/detailSchedule/DetailScheduleModal.tsx
@@ -4,16 +4,18 @@ import { useModal } from '@/hooks/useModal'
 import DetailScheduleInfo from './DetailScheduleInfo'
 import DetailScheduleSelectedParticipants from './DetailScheduleSelectedParticipants'
 import dayjs from '@/lib/dayjs'
+import { storeSchedule } from '@/store/storeSchedule'
 
 const DetailScheduleModal = () => {
   const { modalToModal } = useModal()
+  const { setPreviousSchedule } = storeSchedule()
   const formattedCreatedScheduleDate = dayjs(dummySchedule.create_at).format(
     'LLL'
   )
 
-  const handleClickEdit = (e: React.MouseEvent) => {
-    e.preventDefault()
-    modalToModal('/modal/add_schedule', '스케줄 수정')
+  const handleClickEdit = () => {
+    setPreviousSchedule(dummySchedule)
+    modalToModal('/modal/edit_schedule', '스케줄 수정')
   }
 
   return (

--- a/src/components/modal/detailSchedule/DetailScheduleModal.tsx
+++ b/src/components/modal/detailSchedule/DetailScheduleModal.tsx
@@ -8,13 +8,14 @@ import { storeSchedule } from '@/store/storeSchedule'
 
 const DetailScheduleModal = () => {
   const { modalToModal } = useModal()
-  const { setPreviousSchedule } = storeSchedule()
+  const { setPreviousSchedule, setIsEdit } = storeSchedule()
   const formattedCreatedScheduleDate = dayjs(dummySchedule.created_at).format(
     'LLL'
   )
 
   const handleClickEdit = () => {
     setPreviousSchedule(dummySchedule)
+    setIsEdit(true)
     modalToModal('/modal/edit_schedule', '스케줄 수정')
   }
 

--- a/src/components/modal/detailSchedule/DetailScheduleSelectedParticipants.tsx
+++ b/src/components/modal/detailSchedule/DetailScheduleSelectedParticipants.tsx
@@ -10,7 +10,7 @@ const DetailScheduleSelectedParticipants = () => {
   return (
     <section className="flex flex-col gap-2">
       <h4 className="text-sm font-medium text-gray-700">
-        참여자 목록 {`(${dummySchedule.participants.length}명)`}
+        참여자 목록 {`(${participants.length}명)`}
       </h4>
       <ul className="flex max-h-48 flex-col gap-2 overflow-y-auto rounded-lg border border-gray-200 p-4">
         {leader && (

--- a/src/components/modal/schedule/ScheduleInfo.tsx
+++ b/src/components/modal/schedule/ScheduleInfo.tsx
@@ -1,5 +1,6 @@
 import { BasicInput } from '@/components/basicComponents/input/BasicInput'
-import { useState } from 'react'
+import { storeSchedule } from '@/store/storeSchedule'
+import { useEffect, useState } from 'react'
 
 const ScheduleInfo = () => {
   const [titleValue, setTitleValue] = useState('')
@@ -7,6 +8,21 @@ const ScheduleInfo = () => {
   const [dateValue, setDateValue] = useState('')
   const [startTimeValue, setStartTimeValue] = useState('')
   const [endTimeValue, setEndTimeValue] = useState('')
+
+  const { previousSchedule } = storeSchedule()
+  const isEdit =
+    window.location.pathname === '/modal/edit_schedule' ? true : false
+
+  useEffect(() => {
+    if (!isEdit) return
+    if (isEdit && previousSchedule) {
+      setTitleValue(previousSchedule.title)
+      setGoalValue(previousSchedule.goal)
+      setDateValue(previousSchedule.date)
+      setStartTimeValue(previousSchedule.startTime)
+      setEndTimeValue(previousSchedule.endTime)
+    }
+  }, [isEdit, previousSchedule])
 
   return (
     <section className="flex flex-col gap-6">

--- a/src/components/modal/schedule/ScheduleInfo.tsx
+++ b/src/components/modal/schedule/ScheduleInfo.tsx
@@ -9,9 +9,7 @@ const ScheduleInfo = () => {
   const [startTimeValue, setStartTimeValue] = useState('')
   const [endTimeValue, setEndTimeValue] = useState('')
 
-  const { previousSchedule } = storeSchedule()
-  const isEdit =
-    window.location.pathname === '/modal/edit_schedule' ? true : false
+  const { previousSchedule, isEdit } = storeSchedule()
 
   useEffect(() => {
     if (!isEdit) return

--- a/src/components/modal/schedule/ScheduleModal.tsx
+++ b/src/components/modal/schedule/ScheduleModal.tsx
@@ -4,6 +4,7 @@ import ScheduleInfo from './ScheduleInfo'
 import { BasicButton } from '@/components/basicComponents/BasicButton/BasicButton'
 import { useModal } from '@/hooks/useModal'
 import { storeSchedule } from '@/store/storeSchedule'
+import { useParams } from 'react-router'
 
 type Participant = {
   id: number
@@ -15,6 +16,7 @@ const ScheduleModal = () => {
   const [selectedParticipants, setSelectedParticipants] = useState<
     Participant[]
   >([])
+  const params = useParams<{ id: string }>()
   const { closeModal, modalToModal } = useModal()
   const { previousSchedule, isEdit, clearSchedules } = storeSchedule()
 
@@ -29,7 +31,7 @@ const ScheduleModal = () => {
     e.preventDefault()
     if (isEdit) {
       clearSchedules()
-      modalToModal('/modal/schedule_detail', '스케줄 상세보기')
+      modalToModal(`/modal/schedule_detail/${params.id}`, '스케줄 상세보기')
       return
     }
     clearSchedules()

--- a/src/components/modal/schedule/ScheduleModal.tsx
+++ b/src/components/modal/schedule/ScheduleModal.tsx
@@ -1,8 +1,9 @@
 import ScheduleParticipantsSelecting from './ScheduleParticipantsSelecting'
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import ScheduleInfo from './ScheduleInfo'
 import { BasicButton } from '@/components/basicComponents/BasicButton/BasicButton'
 import { useModal } from '@/hooks/useModal'
+import { storeSchedule } from '@/store/storeSchedule'
 
 type Participant = {
   id: number
@@ -15,6 +16,16 @@ const ScheduleModal = () => {
     Participant[]
   >([])
   const { closeModal } = useModal()
+  const { previousSchedule } = storeSchedule()
+  const isEdit =
+    window.location.pathname === '/modal/edit_schedule' ? true : false
+
+  useEffect(() => {
+    if (isEdit) return // 수정이 아닌 경우 초기화하지 않음
+    if (previousSchedule) {
+      setSelectedParticipants(previousSchedule.participants)
+    }
+  }, [isEdit, previousSchedule])
 
   const handleClickCancel = (e: React.MouseEvent) => {
     e.preventDefault()

--- a/src/components/modal/schedule/ScheduleModal.tsx
+++ b/src/components/modal/schedule/ScheduleModal.tsx
@@ -21,7 +21,7 @@ const ScheduleModal = () => {
     window.location.pathname === '/modal/edit_schedule' ? true : false
 
   useEffect(() => {
-    if (isEdit) return // 수정이 아닌 경우 초기화하지 않음
+    if (!isEdit) return // 수정이 아닌 경우 초기화하지 않음
     if (previousSchedule) {
       setSelectedParticipants(previousSchedule.participants)
     }
@@ -29,6 +29,10 @@ const ScheduleModal = () => {
 
   const handleClickCancel = (e: React.MouseEvent) => {
     e.preventDefault()
+    if (isEdit) {
+      window.history.back()
+      return
+    }
     closeModal()
   }
 
@@ -47,7 +51,7 @@ const ScheduleModal = () => {
           취소
         </BasicButton>
         <BasicButton type="primary" size="large">
-          추가하기
+          {isEdit ? '수정하기' : '추가하기'}
         </BasicButton>
       </footer>
     </form>

--- a/src/components/modal/schedule/ScheduleModal.tsx
+++ b/src/components/modal/schedule/ScheduleModal.tsx
@@ -16,7 +16,7 @@ const ScheduleModal = () => {
     Participant[]
   >([])
   const { closeModal } = useModal()
-  const { previousSchedule } = storeSchedule()
+  const { previousSchedule, clearSchedules } = storeSchedule()
   const isEdit =
     window.location.pathname === '/modal/edit_schedule' ? true : false
 
@@ -30,9 +30,11 @@ const ScheduleModal = () => {
   const handleClickCancel = (e: React.MouseEvent) => {
     e.preventDefault()
     if (isEdit) {
+      clearSchedules()
       window.history.back()
       return
     }
+    clearSchedules()
     closeModal()
   }
 

--- a/src/components/modal/schedule/ScheduleModal.tsx
+++ b/src/components/modal/schedule/ScheduleModal.tsx
@@ -15,10 +15,8 @@ const ScheduleModal = () => {
   const [selectedParticipants, setSelectedParticipants] = useState<
     Participant[]
   >([])
-  const { closeModal } = useModal()
-  const { previousSchedule, clearSchedules } = storeSchedule()
-  const isEdit =
-    window.location.pathname === '/modal/edit_schedule' ? true : false
+  const { closeModal, modalToModal } = useModal()
+  const { previousSchedule, isEdit, clearSchedules } = storeSchedule()
 
   useEffect(() => {
     if (!isEdit) return // 수정이 아닌 경우 초기화하지 않음
@@ -31,7 +29,7 @@ const ScheduleModal = () => {
     e.preventDefault()
     if (isEdit) {
       clearSchedules()
-      window.history.back()
+      modalToModal('/modal/schedule_detail', '스케줄 상세보기')
       return
     }
     clearSchedules()

--- a/src/components/modal/schedule/ScheduleParticipantsSelecting.tsx
+++ b/src/components/modal/schedule/ScheduleParticipantsSelecting.tsx
@@ -20,6 +20,8 @@ const ScheduleParticipantsSelecting = ({
 
   const leader = participants.find((participant) => participant.is_leader)
   const others = participants.filter((participant) => !participant.is_leader)
+  const isChecked = (id: number) =>
+    selectedParticipants.some((participant) => participant.id === id)
 
   const handleParticipantChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const { value, checked } = e.target
@@ -45,41 +47,44 @@ const ScheduleParticipantsSelecting = ({
         참여자 선택 <span className="text-danger-600">*</span>
       </h3>
       <div className="flex max-h-48 flex-col gap-2 overflow-y-auto rounded-md border border-gray-300 p-4">
-        <div className="flex items-center gap-2">
-          <label
-            htmlFor={leader?.nickname}
-            className="relative flex items-center gap-2 text-sm"
-          >
-            <input
-              id={leader?.nickname}
-              type="checkbox"
-              value={leader?.nickname}
-              onChange={handleParticipantChange}
-              className="peer checked:bg-primary-500 h-3 w-3 appearance-none rounded-xs border border-gray-600 checked:border-none focus:outline-none"
-              required
-            />
-            <span className="absolute top-1/2 left-1.5 -translate-x-1/2 -translate-y-1/2 transform text-white opacity-0 peer-checked:opacity-100">
-              <svg
-                xmlns="http://www.w3.org/2000/svg"
-                className="h-3 w-3"
-                viewBox="0 0 20 20"
-                fill="currentColor"
-                stroke="currentColor"
-                strokeWidth="1"
-              >
-                <path
-                  fillRule="evenodd"
-                  d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z"
-                  clipRule="evenodd"
-                ></path>
-              </svg>
-            </span>
-            {leader?.nickname}
-            <span className="bg-primary-100 text-primary-800 rounded-sm px-2 py-1 text-xs">
-              리더
-            </span>
-          </label>
-        </div>
+        {leader && (
+          <div className="flex items-center gap-2">
+            <label
+              htmlFor={leader.nickname}
+              className="relative flex items-center gap-2 text-sm"
+            >
+              <input
+                id={leader.nickname}
+                type="checkbox"
+                value={leader.nickname}
+                checked={isChecked(leader.id)}
+                onChange={handleParticipantChange}
+                className="peer checked:bg-primary-500 h-3 w-3 appearance-none rounded-xs border border-gray-600 checked:border-none focus:outline-none"
+                required
+              />
+              <span className="absolute top-1/2 left-1.5 -translate-x-1/2 -translate-y-1/2 transform text-white opacity-0 peer-checked:opacity-100">
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  className="h-3 w-3"
+                  viewBox="0 0 20 20"
+                  fill="currentColor"
+                  stroke="currentColor"
+                  strokeWidth="1"
+                >
+                  <path
+                    fillRule="evenodd"
+                    d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z"
+                    clipRule="evenodd"
+                  ></path>
+                </svg>
+              </span>
+              {leader.nickname}
+              <span className="bg-primary-100 text-primary-800 rounded-sm px-2 py-1 text-xs">
+                리더
+              </span>
+            </label>
+          </div>
+        )}
         {others.map((participant) => (
           <div key={participant.id} className="flex items-center gap-2">
             <label
@@ -90,6 +95,7 @@ const ScheduleParticipantsSelecting = ({
                 id={participant.nickname}
                 type="checkbox"
                 value={participant.nickname}
+                checked={isChecked(participant.id)}
                 onChange={handleParticipantChange}
                 className="peer checked:bg-primary-500 h-3 w-3 appearance-none rounded-xs border border-gray-600 checked:border-none focus:outline-none"
                 required

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -53,6 +53,10 @@ const router = createBrowserRouter([
             Component: ScheduleModal,
           },
           {
+            path: '/modal/edit_schedule',
+            Component: ScheduleModal,
+          },
+          {
             path: '/modal/schedule_detail',
             Component: DetailScheduleModal,
           },

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -53,11 +53,11 @@ const router = createBrowserRouter([
             Component: ScheduleModal,
           },
           {
-            path: '/modal/edit_schedule',
+            path: '/modal/edit_schedule/:id',
             Component: ScheduleModal,
           },
           {
-            path: '/modal/schedule_detail',
+            path: '/modal/schedule_detail/:id',
             Component: DetailScheduleModal,
           },
         ],

--- a/src/store/storeSchedule.ts
+++ b/src/store/storeSchedule.ts
@@ -1,0 +1,19 @@
+import type { Schedule } from '@/types/Schedule'
+import { create } from 'zustand'
+
+interface StoreSchedule {
+  previousSchedule: Schedule | null
+
+  setPreviousSchedule: (schedule: Schedule) => void
+  clearSchedules: () => void
+}
+
+export const storeSchedule = create<StoreSchedule>((set) => ({
+  previousSchedule: null,
+  newSchedule: null,
+
+  setPreviousSchedule: (schedule: Schedule) =>
+    set({ previousSchedule: schedule }),
+
+  clearSchedules: () => set({ previousSchedule: null }),
+}))

--- a/src/store/storeSchedule.ts
+++ b/src/store/storeSchedule.ts
@@ -2,18 +2,33 @@ import type { Schedule } from '@/types/Schedule'
 import { create } from 'zustand'
 
 interface StoreSchedule {
-  previousSchedule: Schedule | null
+  previousSchedule: Schedule
+  newSchedule: Schedule
 
   setPreviousSchedule: (schedule: Schedule) => void
+  setNewSchedule: (schedule: Schedule) => void
   clearSchedules: () => void
 }
 
+const initialSchedule: Schedule = {
+  id: 0,
+  title: '',
+  goal: '',
+  date: '',
+  startTime: '',
+  endTime: '',
+  participants: [],
+}
+
 export const storeSchedule = create<StoreSchedule>((set) => ({
-  previousSchedule: null,
-  newSchedule: null,
+  previousSchedule: initialSchedule,
+  newSchedule: initialSchedule,
 
   setPreviousSchedule: (schedule: Schedule) =>
     set({ previousSchedule: schedule }),
 
-  clearSchedules: () => set({ previousSchedule: null }),
+  setNewSchedule: (schedule: Schedule) => set({ newSchedule: schedule }),
+
+  clearSchedules: () =>
+    set({ previousSchedule: initialSchedule, newSchedule: initialSchedule }),
 }))

--- a/src/store/storeSchedule.ts
+++ b/src/store/storeSchedule.ts
@@ -5,13 +5,15 @@ interface StoreSchedule {
   previousSchedule: Schedule
   newSchedule: Schedule
 
+  isEdit: boolean
+
   setPreviousSchedule: (schedule: Schedule) => void
   setNewSchedule: (schedule: Schedule) => void
+  setIsEdit: (isEdit: boolean) => void
   clearSchedules: () => void
 }
 
 const initialSchedule: Schedule = {
-  id: 0,
   title: '',
   goal: '',
   date: '',
@@ -24,11 +26,19 @@ export const storeSchedule = create<StoreSchedule>((set) => ({
   previousSchedule: initialSchedule,
   newSchedule: initialSchedule,
 
+  isEdit: false,
+
   setPreviousSchedule: (schedule: Schedule) =>
     set({ previousSchedule: schedule }),
 
   setNewSchedule: (schedule: Schedule) => set({ newSchedule: schedule }),
 
+  setIsEdit: (isEdit: boolean) => set({ isEdit }),
+
   clearSchedules: () =>
-    set({ previousSchedule: initialSchedule, newSchedule: initialSchedule }),
+    set({
+      previousSchedule: initialSchedule,
+      newSchedule: initialSchedule,
+      isEdit: false,
+    }),
 }))

--- a/src/test/TestModal.tsx
+++ b/src/test/TestModal.tsx
@@ -4,7 +4,7 @@ import { useModal } from '@/hooks/useModal'
 
 const routeArr = [
   { path: '/modal/add_schedule', title: '새 스케줄 추가' },
-  { path: '/modal/schedule_detail', title: '스케줄 상세' },
+  { path: '/modal/schedule_detail/1', title: '스케줄 상세' },
   { path: '/modal/date_picker', title: 'date_picker' },
   { path: '/modal/choosing_lecture', title: 'choosing_lecture' },
 ]

--- a/src/types/Schedule.ts
+++ b/src/types/Schedule.ts
@@ -11,6 +11,6 @@ export type Schedule = {
   date: string
   startTime: string
   endTime: string
-  create_at?: string
+  created_at?: string
   participants: ScheduleParticipant[]
 }

--- a/src/types/Schedule.ts
+++ b/src/types/Schedule.ts
@@ -5,12 +5,12 @@ type ScheduleParticipant = {
 }
 
 export type Schedule = {
-  id: number
+  id?: number
   title: string
   goal: string
   date: string
   startTime: string
   endTime: string
-  create_at: string
+  create_at?: string
   participants: ScheduleParticipant[]
 }

--- a/src/types/Schedule.ts
+++ b/src/types/Schedule.ts
@@ -1,0 +1,16 @@
+type ScheduleParticipant = {
+  id: number
+  nickname: string
+  is_leader: boolean
+}
+
+export type Schedule = {
+  id: number
+  title: string
+  goal: string
+  date: string
+  startTime: string
+  endTime: string
+  create_at: string
+  participants: ScheduleParticipant[]
+}


### PR DESCRIPTION
## 📌 제목

- Feat/63 edit schedule UI

## 💡 개요

- 일정 수정시에 일정추가 모달과 같은 모달을 사용하고, 안의 내용만 달라지게끔 한다.

## 📝 상세 내용

- 수정버튼 클릭 시 일정추가와 동일한 컴포넌트를 렌더링
- 일정추가와 수정의 엔드포인트를 다르게 설정
- 엔드포인트에따라서 input의 초기 value 값이 달라짐

## 화면

<img width="489" height="630" alt="image" src="https://github.com/user-attachments/assets/a3971122-d35e-485f-a78e-3ec3ab10bb53" />


## ✅ 체크리스트

- [x] 코드에 불필요한 console.log 제거
- [x] lint 검사 통과
- [ ] 테스트 통과
- [ ] 관련 문서/README 업데이트

## 🔗 관련 이슈

- close #63 
