### PR TITLE
Feat/69 date picker feature

### DIFF
--- a/src/components/modal/datePicker/DatePickerCaption.tsx
+++ b/src/components/modal/datePicker/DatePickerCaption.tsx
@@ -1,24 +1,23 @@
 import { useDayPicker, type MonthCaptionProps } from 'react-day-picker'
 import { ChevronLeft, ChevronRight } from 'lucide-react'
+import dayjs from '@/lib/dayjs'
 
 const DatePickerCaption = (props: MonthCaptionProps) => {
   const { goToMonth, nextMonth, previousMonth, dayPickerProps } = useDayPicker()
   const { startMonth, endMonth } = dayPickerProps
 
   const date = props.calendarMonth.date
-  const year = date.getFullYear()
-  const month = date.getMonth() + 1
+  const year = dayjs(date).get('year')
+  const month = dayjs(date).get('month') + 1
 
   const canGoPrev =
-    !startMonth ||
-    date > new Date(startMonth.getFullYear(), startMonth.getMonth(), 1)
-  const canGoNext =
-    !endMonth || date < new Date(endMonth.getFullYear(), endMonth.getMonth(), 1)
+    !startMonth || date > dayjs(startMonth).set('date', 1).toDate()
+  const canGoNext = !endMonth || date < dayjs(endMonth).set('date', 1).toDate()
 
   const goToday = () => {
-    const today = new Date()
+    const today = dayjs()
     // 날짜는 1일로 맞춰서 월 전환만 하도록
-    goToMonth?.(new Date(today.getFullYear(), today.getMonth(), 1))
+    goToMonth?.(today.set('date', 1).toDate())
   }
 
   return (
@@ -30,7 +29,7 @@ const DatePickerCaption = (props: MonthCaptionProps) => {
         onClick={() =>
           canGoPrev &&
           previousMonth &&
-          goToMonth?.(new Date(date.getFullYear(), date.getMonth() - 1, 1))
+          goToMonth?.(dayjs(date).subtract(1, 'month').toDate())
         }
       >
         <ChevronLeft />
@@ -39,7 +38,10 @@ const DatePickerCaption = (props: MonthCaptionProps) => {
         <span className="text-lg font-bold text-gray-900">
           {year}년 {month}월
         </span>
-        <button className="text-primary-500 text-sm" onClick={goToday}>
+        <button
+          className="text-primary-500 hover:text-primary-600 text-sm hover:cursor-pointer"
+          onClick={goToday}
+        >
           오늘
         </button>
       </div>
@@ -50,7 +52,7 @@ const DatePickerCaption = (props: MonthCaptionProps) => {
         onClick={() =>
           canGoNext &&
           nextMonth &&
-          goToMonth?.(new Date(date.getFullYear(), date.getMonth() + 1, 1))
+          goToMonth?.(dayjs(date).add(1, 'month').toDate())
         }
       >
         <ChevronRight />

--- a/src/components/modal/datePicker/DatePickerFooter.tsx
+++ b/src/components/modal/datePicker/DatePickerFooter.tsx
@@ -1,17 +1,29 @@
 import { useModal } from '@/hooks/useModal'
 import { BasicButton } from '../../basicComponents/BasicButton/BasicButton'
+import { storeStudyGroupDate } from '@/store/storeStudyGroupDate'
 
 type DatePickerFooterProps = {
   selected: Date | undefined
+  target?: string | null
 }
 
-const DatePickerFooter = ({ selected }: DatePickerFooterProps) => {
+const DatePickerFooter = ({ selected, target }: DatePickerFooterProps) => {
   const { closeModal } = useModal()
+  const { setNewStartDate, setNewEndDate } = storeStudyGroupDate()
 
   const handleClickCancel = (e: React.MouseEvent) => {
     e.preventDefault()
     closeModal()
   }
+
+  const handleClickConfirm = (e: React.MouseEvent) => {
+    e.preventDefault()
+    if (!selected) return
+    if (target === 'start') setNewStartDate(selected)
+    if (target === 'end') setNewEndDate(selected)
+    closeModal()
+  }
+
   return (
     <footer className="flex w-full items-center justify-between border-t border-gray-300 p-6">
       <p className="text-gray-600">
@@ -20,14 +32,10 @@ const DatePickerFooter = ({ selected }: DatePickerFooterProps) => {
           : '날짜를 선택하세요.'}
       </p>
       <div className="flex gap-3">
-        <BasicButton
-          type="outline"
-          size="large"
-          onClick={(e) => handleClickCancel(e)}
-        >
+        <BasicButton type="outline" size="large" onClick={handleClickCancel}>
           취소
         </BasicButton>
-        <BasicButton type="secondary" size="large">
+        <BasicButton type="secondary" size="large" onClick={handleClickConfirm}>
           선택완료
         </BasicButton>
       </div>

--- a/src/components/modal/datePicker/DatePickerModal.tsx
+++ b/src/components/modal/datePicker/DatePickerModal.tsx
@@ -1,35 +1,68 @@
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { DayPicker } from 'react-day-picker'
 import { ko } from 'react-day-picker/locale'
 import 'react-day-picker/style.css'
 import DatePickerCaption from './DatePickerCaption'
 import DatePickerFooter from './DatePickerFooter'
+import dayjs from '@/lib/dayjs'
+import { useSearchParams } from 'react-router'
+import { storeStudyGroupDate } from '@/store/storeStudyGroupDate'
 
 const DatePickerModal = () => {
   const [selected, setSelected] = useState<Date>()
+  const params = useSearchParams()
+  const target = params[0].get('target')
+
+  const { previousStartDate, previousEndDate } = storeStudyGroupDate()
+
+  const today = dayjs().toDate()
+
+  useEffect(() => {
+    if (target === 'start' && previousStartDate) {
+      setSelected(previousStartDate)
+    }
+    if (target === 'end' && previousEndDate) {
+      setSelected(previousEndDate)
+    }
+  }, [target, previousStartDate, previousEndDate])
 
   return (
     <div className="flex w-[448px] flex-col items-center rounded-xl">
       <DayPicker
         mode="single"
-        disabled={{ before: new Date() }}
+        disabled={
+          target === 'start'
+            ? {
+                before: today,
+                after: previousEndDate
+                  ? dayjs(previousEndDate).subtract(5, 'day').toDate()
+                  : undefined,
+              }
+            : {
+                before: previousStartDate
+                  ? dayjs(previousStartDate).add(5, 'day').toDate()
+                  : dayjs(today).add(5, 'day').toDate(),
+              }
+        }
         locale={ko}
         navLayout="around"
         showOutsideDays
         selected={selected}
         onSelect={setSelected}
+        startMonth={dayjs(today).set('date', 1).toDate()}
         components={{ MonthCaption: DatePickerCaption }}
         classNames={{
           today: 'text-black',
           selected: 'border-2 rounded-full border-primary-400',
           month_caption: 'hidden',
           chevron: 'hidden',
-          outside: 'text-gray-400',
+          outside: 'text-gray-300',
           day_button: 'w-[53.7px] h-[40px]',
+          disabled: 'text-gray-400 hover:cursor-not-allowed',
         }}
         className="py-6"
       />
-      <DatePickerFooter selected={selected} />
+      <DatePickerFooter selected={selected} target={target} />
     </div>
   )
 }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -16,6 +16,7 @@ import LectureChoosingModal from './components/modal/lectureChoosing/LectureChoo
 import ScheduleModal from './components/modal/schedule/ScheduleModal'
 import DetailScheduleModal from './components/modal/detailSchedule/DetailScheduleModal'
 import StudyGroup from './pages/StudyGroup'
+import CreateStudyGroup from './pages/study-groups/CreateStudyGroup'
 
 const router = createBrowserRouter([
   {
@@ -25,6 +26,10 @@ const router = createBrowserRouter([
       {
         path: '/',
         Component: StudyGroup,
+      },
+      {
+        path: '/create_study_group',
+        Component: CreateStudyGroup,
       },
       {
         path: '/testModal',

--- a/src/pages/StudyGroup.tsx
+++ b/src/pages/StudyGroup.tsx
@@ -5,6 +5,7 @@ import React, { useState } from 'react'
 import type { StudyGroup as StudyGroupType } from '@/types/StudyGroupTypes'
 import StudyCard from '@/components/studyGroup/StudyCard'
 import { studyGroupList } from '@/assets/dummyData/studiesData'
+import { useNavigate } from 'react-router'
 
 const SearchBar: React.FC = () => (
   <div className="mb-8 w-1/3">
@@ -89,6 +90,8 @@ const StudySection: React.FC<{ title: string; studies: StudyGroupType[] }> = ({
 }
 
 const StudyGroup = () => {
+  const navigate = useNavigate()
+
   const ongoingStudyGroupList = studyGroupList.filter(
     (study) => study.status === 'ONGOING'
   )
@@ -101,6 +104,10 @@ const StudyGroup = () => {
   // const completedWithLeader = studiesCompleted.map((s, i) =>
   //   i === 0 ? { ...s, isLeader: true } : s
   // )
+
+  const handleClickCreateStudy = () => {
+    navigate('/create_study_group')
+  }
 
   return (
     <div className="min-h-screen bg-white px-20 pt-[65px] pb-20">
@@ -115,7 +122,11 @@ const StudyGroup = () => {
               함께 공부하며 성장하는 스터디 그룹에 참여해보세요
             </p>
           </div>
-          <BasicButton type="primary" size="medium">
+          <BasicButton
+            type="primary"
+            onClick={handleClickCreateStudy}
+            size="medium"
+          >
             <Plus size={16} /> 새 스터디 만들기
           </BasicButton>
         </div>

--- a/src/pages/study-groups/CreateStudyGroup.tsx
+++ b/src/pages/study-groups/CreateStudyGroup.tsx
@@ -7,6 +7,8 @@ import LectureSection from './sections/LectureSection'
 import BasicModal from '../../components/basicComponents/basicModal/BasicModal'
 import { studyGroupFormMock } from '../../assets/dummyData/dummyStudyGroup'
 import { BasicButton } from '../../components/basicComponents/BasicButton/BasicButton'
+import { storeStudyGroupDate } from '@/store/storeStudyGroupDate'
+import dayjs from '@/lib/dayjs'
 
 export default function CreateStudyGroup() {
   const [form, setForm] = useState<StudyGroupForm>({
@@ -20,6 +22,7 @@ export default function CreateStudyGroup() {
   })
 
   const [isEdit, setIsEdit] = useState(false)
+  const { newStartDate, newEndDate, clearDates } = storeStudyGroupDate()
 
   useEffect(() => {
     if (window.location.pathname.includes('edit')) {
@@ -46,6 +49,12 @@ export default function CreateStudyGroup() {
     } else {
       alert('스터디 그룹이 생성되었습니다.')
     }
+    setForm({
+      ...form,
+      startDate: dayjs(newStartDate).toISOString(),
+      endDate: dayjs(newEndDate).toISOString(),
+    })
+    clearDates()
   }
 
   const handleBack = () => window.history.back()

--- a/src/pages/study-groups/CreateStudyGroup.tsx
+++ b/src/pages/study-groups/CreateStudyGroup.tsx
@@ -9,6 +9,7 @@ import { studyGroupFormMock } from '../../assets/dummyData/dummyStudyGroup'
 import { BasicButton } from '../../components/basicComponents/BasicButton/BasicButton'
 import { storeStudyGroupDate } from '@/store/storeStudyGroupDate'
 import dayjs from '@/lib/dayjs'
+import { useNavigate } from 'react-router'
 
 export default function CreateStudyGroup() {
   const [form, setForm] = useState<StudyGroupForm>({
@@ -23,6 +24,7 @@ export default function CreateStudyGroup() {
 
   const [isEdit, setIsEdit] = useState(false)
   const { newStartDate, newEndDate, clearDates } = storeStudyGroupDate()
+  const navigate = useNavigate()
 
   useEffect(() => {
     if (window.location.pathname.includes('edit')) {
@@ -57,7 +59,10 @@ export default function CreateStudyGroup() {
     clearDates()
   }
 
-  const handleBack = () => window.history.back()
+  const handleBack = () => {
+    clearDates()
+    navigate('/')
+  }
 
   return (
     <div className="relative min-h-screen w-full bg-[#FAFAFA] py-10">

--- a/src/pages/study-groups/CreateStudyGroup.tsx
+++ b/src/pages/study-groups/CreateStudyGroup.tsx
@@ -51,7 +51,7 @@ export default function CreateStudyGroup() {
   const handleBack = () => window.history.back()
 
   return (
-    <div className="relative min-h-screen bg-[#FAFAFA] py-10">
+    <div className="relative min-h-screen w-full bg-[#FAFAFA] py-10">
       <div className="mx-auto mb-8 flex h-[96px] w-[832px] items-center gap-[16px]">
         <button
           onClick={handleBack}

--- a/src/pages/study-groups/sections/PeriodSection.tsx
+++ b/src/pages/study-groups/sections/PeriodSection.tsx
@@ -1,9 +1,11 @@
-import { useEffect } from 'react'
+// import { useEffect } from 'react'
 import { useModal } from '../../../hooks/useModal'
 import { BasicInput } from '../../../components/basicComponents/input/BasicInput'
 import type { StudyGroupForm } from '../../../types/StudyGroupTypes'
 import CustomSlider from '../../../components/slider/CustomSlider'
 import { Calendar } from 'lucide-react'
+import { storeStudyGroupDate } from '@/store/storeStudyGroupDate'
+import dayjs from '@/lib/dayjs'
 
 interface Props {
   form: StudyGroupForm
@@ -12,6 +14,12 @@ interface Props {
 
 export default function PeriodSection({ form, setForm }: Props) {
   const { openModal } = useModal()
+  const { previousStartDate, previousEndDate } = storeStudyGroupDate()
+
+  const startDate = previousStartDate
+    ? dayjs(previousStartDate).format('L')
+    : ''
+  const endDate = previousEndDate ? dayjs(previousEndDate).format('L') : ''
 
   const handleOpenDatePicker = (type: 'start' | 'end') => {
     openModal(
@@ -19,28 +27,6 @@ export default function PeriodSection({ form, setForm }: Props) {
       type === 'start' ? '스터디 시작일 선택' : '스터디 종료일 선택'
     )
   }
-
-  useEffect(() => {
-    const handleDateSelected = (
-      e: CustomEvent<{ target: 'start' | 'end'; date: string }>
-    ) => {
-      const { target, date } = e.detail
-      setForm((prev) => ({
-        ...prev,
-        ...(target === 'start' ? { startDate: date } : { endDate: date }),
-      }))
-    }
-
-    window.addEventListener(
-      'date-selected',
-      handleDateSelected as EventListener
-    )
-    return () =>
-      window.removeEventListener(
-        'date-selected',
-        handleDateSelected as EventListener
-      )
-  }, [setForm])
 
   const handleSliderChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const newValue = Number(e.target.value)
@@ -62,7 +48,7 @@ export default function PeriodSection({ form, setForm }: Props) {
             <BasicInput
               name="startDate"
               placeholder="날짜를 선택하세요"
-              value={form.startDate}
+              value={startDate}
               readOnly
               onClick={() => handleOpenDatePicker('start')}
             />
@@ -81,7 +67,7 @@ export default function PeriodSection({ form, setForm }: Props) {
             <BasicInput
               name="endDate"
               placeholder="날짜를 선택하세요"
-              value={form.endDate}
+              value={endDate}
               readOnly
               onClick={() => handleOpenDatePicker('end')}
             />

--- a/src/pages/study-groups/sections/PeriodSection.tsx
+++ b/src/pages/study-groups/sections/PeriodSection.tsx
@@ -14,7 +14,10 @@ export default function PeriodSection({ form, setForm }: Props) {
   const { openModal } = useModal()
 
   const handleOpenDatePicker = (type: 'start' | 'end') => {
-    openModal(`/modal/date_picker?target=${type}`, '날짜 선택')
+    openModal(
+      `/modal/date_picker?target=${type}`,
+      type === 'start' ? '스터디 시작일 선택' : '스터디 종료일 선택'
+    )
   }
 
   useEffect(() => {

--- a/src/store/storeStudyGroupDate.ts
+++ b/src/store/storeStudyGroupDate.ts
@@ -1,0 +1,46 @@
+import { create } from 'zustand'
+
+interface StoreStudyGroupDate {
+  previousStartDate: Date | null
+  newStartDate: Date | null
+  previousEndDate: Date | null
+  newEndDate: Date | null
+
+  isEditStartDate: boolean
+  isEditEndDate: boolean
+
+  setPreviousStartDate: (date: Date | null) => void
+  setNewStartDate: (date: Date | null) => void
+  setPreviousEndDate: (date: Date | null) => void
+  setNewEndDate: (date: Date | null) => void
+  setIsEditStartDate: (isEdit: boolean) => void
+  setIsEditEndDate: (isEdit: boolean) => void
+  clearDates: () => void
+}
+
+export const storeStudyGroupDate = create<StoreStudyGroupDate>((set) => ({
+  previousStartDate: null,
+  newStartDate: null,
+  previousEndDate: null,
+  newEndDate: null,
+
+  isEditStartDate: false,
+  isEditEndDate: false,
+
+  setPreviousStartDate: (date: Date | null) => set({ previousStartDate: date }),
+  setNewStartDate: (date: Date | null) => set({ newStartDate: date }),
+  setPreviousEndDate: (date: Date | null) => set({ previousEndDate: date }),
+  setNewEndDate: (date: Date | null) => set({ newEndDate: date }),
+  setIsEditStartDate: (isEdit: boolean) => set({ isEditStartDate: isEdit }),
+  setIsEditEndDate: (isEdit: boolean) => set({ isEditEndDate: isEdit }),
+
+  clearDates: () =>
+    set({
+      previousStartDate: null,
+      newStartDate: null,
+      previousEndDate: null,
+      newEndDate: null,
+      isEditStartDate: false,
+      isEditEndDate: false,
+    }),
+}))

--- a/src/store/storeStudyGroupDate.ts
+++ b/src/store/storeStudyGroupDate.ts
@@ -28,9 +28,11 @@ export const storeStudyGroupDate = create<StoreStudyGroupDate>((set) => ({
   isEditEndDate: false,
 
   setPreviousStartDate: (date: Date | null) => set({ previousStartDate: date }),
-  setNewStartDate: (date: Date | null) => set({ newStartDate: date }),
+  setNewStartDate: (date: Date | null) =>
+    set({ newStartDate: date, previousStartDate: date }),
   setPreviousEndDate: (date: Date | null) => set({ previousEndDate: date }),
-  setNewEndDate: (date: Date | null) => set({ newEndDate: date }),
+  setNewEndDate: (date: Date | null) =>
+    set({ newEndDate: date, previousEndDate: date }),
   setIsEditStartDate: (isEdit: boolean) => set({ isEditStartDate: isEdit }),
   setIsEditEndDate: (isEdit: boolean) => set({ isEditEndDate: isEdit }),
 


### PR DESCRIPTION
## 📌 제목

- Feat/69 date picker feature

## 💡 개요

- 날짜 선택 모달에서 선택 한 날짜를 스터디 생성 및 수정 페이지에 보여준다.

## 📝 상세 내용

- 선택 날짜를 스토어로 전역상태로 관리한다.
- 시작일과 종료일은 최소 5일 차이나는 날을 선택 할 수 있다.

## ✅ 체크리스트

- [x] 코드에 불필요한 console.log 제거
- [x] lint 검사 통과
- [ ] 테스트 통과
- [ ] 관련 문서/README 업데이트

## 🔗 관련 이슈

- close #69 
