### PR TITLE
Feature/7 - apiLinks 업데이트

### DIFF
--- a/src/api/httpClient.ts
+++ b/src/api/httpClient.ts
@@ -21,6 +21,18 @@ interface HttpClientConfig {
   onError?: (error: AxiosError) => void
 }
 
+const NO_AUTH_URLS_SET = new Set<string>([
+  '/api/v1/auth/refresh',
+  '/api/v1/lectures/categories',
+  // '/api/v1/lectures' GET 의 경우 정확히 일치할때만 패스 되도록 따로 지정이 필요함
+  // (로그인 전에 강의만 살펴보는 경우) => 실제로 지원하는 기능인지 확인 필요
+
+  // (스웨거) NotificationTypeEnum이 제공 되나, 추후에 타입만 따로 받아올 가능성 있음
+  // 로그인전에 타입만 따로 받아오기
+  //    => ux 증진(ui에 표시되는 속도 향상)
+  //    => 불필요한 데이터 통신 비용 증가
+])
+
 /**
  * 토큰 삽입과 요청만 처리
  * 에러는 핸들러로 위임
@@ -52,7 +64,13 @@ export class HttpClient {
     // 요청 인터셉터 - 토큰 자동 삽입
     this.client.interceptors.request.use(
       (config) => {
+        // NO_AUTH_URLS_SET에 포함된 url요청은 인증회피
+        const url = config.url || ''
+        const needsAuth = !NO_AUTH_URLS_SET.has(url)
+        if (needsAuth) return config
+
         const token = this.tokenStorage.getAccessToken()
+
         if (token && config.headers) {
           config.headers.Authorization = `Bearer ${token}`
         }

--- a/src/api/refreshAccessToken.ts
+++ b/src/api/refreshAccessToken.ts
@@ -1,6 +1,14 @@
 import axios from 'axios'
 import { BASE_URL } from './api'
 
+type RefreshAccessToken = {
+  access: string
+}
+
+/**
+ * 리프레쉬 메서드
+ * @returns {} {"access": "string"}
+ */
 export async function refreshAccessToken(): Promise<string | null> {
   try {
     const refreshClient = axios.create({
@@ -9,8 +17,10 @@ export async function refreshAccessToken(): Promise<string | null> {
       headers: { 'Content-Type': 'application/json' },
       timeout: 10000,
     })
-    const res = await refreshClient.post('/api/v1/auth/refresh')
-    if (res.data?.accessToken) return res.data.accessToken
+    const { data } = await refreshClient.post<RefreshAccessToken>(
+      '/api/v1/auth/refresh'
+    )
+    if (data.access) return data.access
     return null
   } catch {
     return null

--- a/src/types/ApiLink.ts
+++ b/src/types/ApiLink.ts
@@ -1,122 +1,156 @@
+// ===================== User =====================
+// type RoleEnum = 'admin' | 'staff' | 'user'
+// (스웨거) RoleEnum이 존재하나 어디에도 쓰이지 않음
+// (예상) UserProfile에 RoleEnum 추가 가능성 있음
+type UserProfile = {
+  id: number
+  email: string
+  nickname: string
+  name: string
+  phone_number: string
+  birthday: string
+  profile_img_url: string
+  created_at: string
+}
+
+// ===================== Notification =====================
+type NotificationTypeEnum =
+  | 'APPLICATIONS_CREATED'
+  | 'APPLICATION_STATUS_APPROVAL'
+  | 'APPLICATION_STATUS_REJECTION'
+  | 'STUDY_MEMBER_JOINED'
+  | 'STUDY_REVIEW_REQUEST'
+  | 'STUDY_SCHEDULE_UPCOMING'
+  | 'STUDY_SCHEDULE_TODAY'
+  | 'STUDY_RECORD_CREATED'
+  | 'SYSTEM'
+  | 'CUSTOM'
+
+type Notification = {
+  id: number
+  user_id: number
+  type_display: string
+  content: string
+  type: NotificationTypeEnum
+  is_read: boolean
+  back_url_link: string
+  user: number
+}
+
 // ===================== Lecture =====================
-// /api/v1/lectures : 강의 목록 조희 요청에 사용자에 따른 추천 항목이 포함됨
-// /api/v1/lectures/recommendations : 사용자에 따른 추천 항목
-// 어째서 메서드가 반복되는가?
-// 명시적 분리 필요 > /api/v1/lectures의 추천항목은 로그인 안하면 어차피 안뜸
-// 로그인시에만 클라쪽에서 /api/v1/lectures/recommendations 에 따로 요청하는 로직 작성이 알맞음
-// 메서드/링크 별로 역할을 명확히 분리하여 관리하는게 맞음
 type LectureCategory = { id: number; name: string }
+// 명시적으로 Enum이 제공되었으나, 추후에 string으로 대체될 가능성 있음
+type DifficultyEnum = 'EASY' | 'NORMAL' | 'HARD'
+type PlatformEnum = 'UDEMY' | 'INFLEARN '
 
 type Lecture = {
+  id: number
   uuid: string
   title: string
   instructor: string
   thumbnail_img_url: string
   categories: LectureCategory[]
-  difficulty: string
+  difficulty: DifficultyEnum
   original_price: number
   discount_price: number
-  platform: string
-  average_rating: number
+  platform: PlatformEnum
+  average_rating: string
+  duration: number
   url_link: string
   is_bookmarked: boolean
 }
 
-// ===================== Lecture:Review =====================
-// rating이 string인 이유?
-// 이후에 10점, 100점 등 확장 예정이면 %로 하는게 낫지않나?
-type rating =
-  | '5_OUT_OF_5_STARS'
-  | '4_OUT_OF_5_STARS'
-  | '3_OUT_OF_5_STARS'
-  | '2_OUT_OF_5_STARS'
-  | '1_OUT_OF_5_STARS'
-
-type Review = {
-  id: number
-  rating: rating
-  content: string
-  created_at: string
-}
-
 // ===================== Study =====================
 
-// ===================== Pagination =====================
-// type Pagenation = {
-//   page: number
-//   page_size: number
-//   total_count: number
-// }
-
-// ===================== etc =====================
-interface DetailEvent {
-  detail: string
+// ===================== Study:Group =====================
+type StudyGroup = {
+  id: number
+  name: string
+  profile_img_url: string
+  max_headcount: number
+  start_at: string
+  end_at: string
+  status: string
+  current_headcount: number
+  is_leader: boolean
+  lectures: Lecture[]
 }
 
-// WSChatErrorEvent 는 {type : error...}
-// ErrorEvent 는 {error: string}
-// 왜 에러 이벤트 타입이 2개인가?
-// 왜 어떤 에러는 DetailEvent 이고 어떤 에러는 ErrorEvent으로 오는가?
-// 에러 타입에만 사용하는게 아니라 detail, error, {type: 'error'...} 으로 섞여서 응답이 오고있음
-// 백엔드 팀들간의 명확한 타입 일치가 필요함
-interface ErrorEvent {
-  error: string
+type StudyGroupDetail = StudyGroup & {
+  // (스웨거) members 타입 누락
+  // 임시로 UserProfile[]로 대체
+  // UserProfile인지 partial<UserProfile>인지 확인 필요
+  members: UserProfile[]
+}
+
+type StudyGroupPost = {
+  name: string
+  profile_img_url: string
+  max_headcount: number
+  start_at: string
+  end_at: string
+  introduction: string
+  // (스웨거) type Lecture 인지 lecture_id 인지 불명확함.
+  lectures: number[]
+}
+
+// ===================== Study:Review =====================
+type StudyReview = {
+  star_rating: number
+  content: string
+}
+
+// ===================== Pagination =====================
+type Pagination<T> = {
+  count: number
+  next: string | null
+  previous: string | null
+  results: T[]
+}
+
+// ===================== etc =====================
+type BaseResponse = {
+  status: string
+  message: string
+  error?: {
+    code: string
+    detail: string
+  }
 }
 
 /**
  * 모든 api 링크에 따른 타입 명시
  *
- * @example
- * 0. req가 없는 요청 예시:
- * api.v1.auth.logout.POST() 로 사용
- * (req_url:"api/v1/auth/logout/", method:"POST") 와 같음
+ * 사용법 상세
+ * https://github.com/OZ-Coding-School/oz_externship_fe_03_team1/pull/74
  *
- * 1. req (body)만 있는 POST 요청 예시:
- * api.v1.studies.groups.POST(req_body) 로 사용
- * (req_url:"api/v1/studies/groups/", method:"POST", { data: req_body }) 와 같음
- *
- * 2. config (params)만 있는 GET 요청 예시:
- * 검색어와 페이지 옵션등을 config 객체로 전달 - 페이지네이션, 검색어 등은 실제 api명세서 필히 체크 할 것(현재 api 명세서 확정 x)
- * api.v1.studies.groups.GET({ params: { search: "typescript", page: 2 } }) 로 사용
- * (req_url:"api/v1/studies/groups/", method:"GET", { params: { search: "typescript", page: 2 } }) 와 같음
- *
- * ----------------------------------------------------------------------
- * 동적 경로 (Path Parameter) 처리 예시:
- * ----------------------------------------------------------------------
- *
- * 3. req(body)와 config(params) 모두 있는 PUT 요청 예시:
- *
- * 3-1. 경로 중간에 파라미터가 있는 경우
- * // 주로 PUT/PATCH 요청에서 ID를 params로, 업데이트 내용을 data로 전달할 때 사용
- * api.v1.studies.groups(id).PUT(req_body) 로 사용
- * (req_url:`api/v1/studies/groups/${id}/`, "PUT", { data: req_body }) 와 같음
- *
- * 3-2. config를 통해 옵션과 데이터 모두 지정이 필요한 경우
- * // 현재 해당 옵션을 반드시 사용해야하는 경우는 찾지 못했으나, 로직상 유동적으로 적용 가능함
- * api.~~~.METHOD({targetOption:myOption, data:req_body}) 로 사용
- * (req_url:`api/~~~/`, "METHOD", { data: req_body, params: { targetOption:myOption } }) 과 같음
- * 위의 3-1의 경우도 ApiLinks만 수정하면
- * api.v1.studies.groups(id).PUT(req_body) 대신
- * api.v1.studies.groups.PUT(req_body, { params: { groupId: id } }) 으로 사용 가능함
- * // 기본적으로 src\api\requestHandler.ts의 RequestConfig는 axios에서 지원되는 대부분의 옵션 적용 가능함
- * // 편의성과 가독성을 위해 경로 중간에 id 등의 파라미터를 지원 가능하도록 조치함(url상 파라미터 위치와 일치)
- *
- * 4. 동적 경로 + req(body) + config(params) 모두 있는 PUT 요청 예시:
- *  URL: /api/v1/studies/groups/123?updateType=partial
- *  // 주로 Path ID + Body + Query Params 조합
- * api.v1.studies.groups(123).PUT({ name: "New Name" }, { params: { updateType: "partial" } }) 로 사용
- *  (req_url:`api/v1/studies/groups/123`, "PUT", { data: { name: "New Name" }, params: { updateType: "partial" } }) 과 같음
+ * 스웨거
+ * https://api.ozcoding.site/api/schema/swagger-ui/#/
  */
 export const ApiLinks = {
   v1: {
-    auth: {
-      logout: {
-        POST: {} as {
-          res: DetailEvent | ErrorEvent
+    users: {
+      me: {
+        GET: {} as {
+          res: UserProfile
         },
       },
     },
+    auth: {
+      // (스웨거) 로그아웃 기능 누락
+      logout: {
+        POST: {} as {
+          res: BaseResponse
+        },
+      },
+    },
+    notifications: {
+      GET: {} as {
+        res: Pagination<Notification>
+      },
+    },
     lectures: {
+      // (스웨거) 검색, 필터, 페이지네이션 기능 누락
       GET: {} as {
         res: {
           count: number
@@ -132,48 +166,49 @@ export const ApiLinks = {
           res: LectureCategory[]
         },
       },
-      dynamicSub: {
-        reviews: {
-          GET: {} as {
-            res: {
-              reviews: Review[]
-            }
-          },
-          // POST: {} as {
-          //   req: {}
-          //   res: {}
-          // },
-          // 리뷰 삭제, 포스팅, 변경 로직 없음
-        },
-      },
     },
     studies: {
       groups: {
+        GET: {} as {
+          res: StudyGroup[]
+        },
         POST: {} as {
-          req: {
-            name: string
-            introduction: string
-            profile_img_url: string
-            start_at: string
-            end_at: string
-            max_headcount: number
-            status: string
-            lectures: Lecture[]
-          }
-          res: {
-            status: number
-            message: string
-            data: {
-              id: number
-              name: string
-              introduction: string
-              profile_img_url: string
-              start_at: string
-              end_at: string
-              max_headcount: number
-              lectures: Lecture[]
-            }
-          }
+          req: StudyGroupPost
+          // (스웨거) post res 응답 누락
+          // 임시로 디테일 이벤트 걸어놓음
+          res: BaseResponse
+        },
+        // (스웨거) 전체 get 메서드와 단일 get 메서드 상의 group 타입이 다름
+        // group_id
+        dynamicSub: {
+          GET: {} as {
+            res: StudyGroupDetail
+          },
+          'delegate-leader': {
+            POST: {} as {
+              req: {
+                target_user_id: number
+              }
+              res: BaseResponse
+            },
+          },
+          leave: {
+            DELETE: {} as {
+              res: BaseResponse
+            },
+          },
+          members: (_member_id: number) => ({
+            DELETE: {} as {
+              res: BaseResponse
+            },
+          }),
+          // (스웨거) 리뷰는 현재 포스트 하나만 존재함
+          // get, delete, patch 누락
+          reviews: {
+            POST: {} as {
+              req: StudyReview
+            },
+          },
         },
       },
     },


### PR DESCRIPTION
## 💡 개요

- feat:인증회피 url 설정
- feat:apiLinks 업데이트(스웨거)

## 📝 상세 내용

- 스웨거 기준으로 apiLinks 업데이트
  - 현재 완성이 되지 않은 상태이기에 없는 부분은 삭제함
  - 스웨거의 미흡한 부분은 주석에 달아놓음
- 인증회피 url 설정
  - src\api\httpClient.ts 의 NO_AUTH_URLS_SET 에 인증 회피할 url을 모아놓음
  - /api/v1/lectures : GET 의 경우 포함되는 모든 경우(.has)에 쓰는 메서드가 아닌 정확히 일치할때만 회피하는 로직을 만들어야 함

## ✅ 체크리스트

- [x] 코드에 불필요한 console.log 제거
- [x] lint 검사 통과
- [ ] 테스트 통과
- [ ] 관련 문서/README 업데이트

## 🔗 관련 이슈

- close #7 
