### PR TITLE
fix:베이직 버튼 알림 버튼-커서 포인터로 변경

### DIFF
--- a/src/components/basicComponents/BasicButton/BasicButton.tsx
+++ b/src/components/basicComponents/BasicButton/BasicButton.tsx
@@ -110,7 +110,7 @@ export const BasicButton = ({
   }
 
   const buttonClass = clsx(
-    'flex items-center justify-center rounded-lg font-medium transition-colors duration-150 focus-visible:ring-2 focus-visible:ring-primary-400 focus:outline-none',
+    'flex items-center justify-center rounded-lg font-medium transition-colors cursor-pointer duration-150 focus-visible:ring-2 focus-visible:ring-primary-400 focus:outline-none',
     sizeMap[size],
     colorSet.bg,
     colorSet.text,

--- a/src/components/navBar/NavBar.tsx
+++ b/src/components/navBar/NavBar.tsx
@@ -39,7 +39,7 @@ const Logo = () => {
 
 const linkArr = [
   { path: '/courses', label: '강의 목록' },
-  { path: '/groups', label: '스터디 그룹' },
+  { path: '/', label: '스터디 그룹' },
   { path: '/jobs', label: '구인 공고' },
 ]
 

--- a/src/components/notification/NotiButton.tsx
+++ b/src/components/notification/NotiButton.tsx
@@ -18,7 +18,7 @@ export const NotiButton = () => {
       <button
         ref={buttonRef}
         onClick={handleClick}
-        className="nav-links relative"
+        className="nav-links relative cursor-pointer"
       >
         <Bell size={22} />
         {notiCount !== 0 && (


### PR DESCRIPTION
## 💡 개요

- 베이직 버튼 알림 버튼-커서 포인터로 변경 및 네브바 스터디 그룹 클릭시 기본 라우팅 주소로 반환

## 📝 상세 내용

-

## ✅ 체크리스트

- [x] 코드에 불필요한 console.log 제거
- [x] lint 검사 통과
- [ ] 테스트 통과
- [ ] 관련 문서/README 업데이트

## 🔗 관련 이슈

- close #이슈번호
