### PR TITLE
feat: 확인 모달창 생성 (#100)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ dist-ssr
 *.sw?
 .history
 .env
+.vercel

--- a/src/components/basicComponents/BasicButton/BasicButton.tsx
+++ b/src/components/basicComponents/BasicButton/BasicButton.tsx
@@ -131,7 +131,7 @@ export const BasicButton = ({
       onMouseLeave={() => isInteractive && setStatus('default')}
       onMouseDown={() => isInteractive && setStatus('active')}
       onMouseUp={() => isInteractive && setStatus('hover')}
-      className={buttonClass + className}
+      className={clsx(buttonClass, className)}
     >
       {isLoading ? (
         <span className="flex items-center gap-2">

--- a/src/components/modal/confirm/ConfirmModal.tsx
+++ b/src/components/modal/confirm/ConfirmModal.tsx
@@ -1,0 +1,40 @@
+import { BasicButton } from '@/components/basicComponents/BasicButton/BasicButton'
+import { storeModalOpen } from '@/store/storeModalOpen'
+
+export const ConfirmModal = () => {
+  const { modalState } = storeModalOpen()
+  const {
+    isConfirm,
+    message,
+    confirmText = '확인',
+    cancelText = '취소',
+    onConfirm,
+    onCancel,
+  } = modalState
+
+  if (!isConfirm) return null
+
+  return (
+    <div className="flex w-sm flex-col justify-center py-5">
+      <div className="flex w-full flex-col pt-3 pb-5 text-center text-xl text-gray-900">
+        {message}
+      </div>
+      <div className="flex w-full justify-between gap-5 px-8 pt-5">
+        <BasicButton
+          variant="outline"
+          onClick={onCancel}
+          className="w-full flex-1"
+        >
+          {cancelText}
+        </BasicButton>
+        <BasicButton
+          variant="primary"
+          onClick={onConfirm}
+          className="w-full flex-1"
+        >
+          {confirmText}
+        </BasicButton>
+      </div>
+    </div>
+  )
+}

--- a/src/hooks/useModal.ts
+++ b/src/hooks/useModal.ts
@@ -17,6 +17,19 @@ import { useNavigate, useLocation } from 'react-router'
  * }
  * ```
  */
+
+type OpenConfirmFn = (
+  message: string,
+  onConfirm: () => void | Promise<void>,
+  options?: {
+    title?: string
+    subTitle?: string
+    confirmText?: string
+    cancelText?: string
+    onCancel?: () => void
+  }
+) => void
+
 export const useModal = () => {
   const navigate = useNavigate()
   const location = useLocation()
@@ -32,6 +45,23 @@ export const useModal = () => {
       title: title,
       subTitle: subTitle,
       isClosing: false,
+    })
+  }
+
+  const openConfirm: OpenConfirmFn = (message, onConfirm, options) => {
+    const currentPath = location.pathname
+    navigate('/modal/confirm') // 라우트는 프로젝트에 맞게
+    setModalState({
+      prevPath: currentPath,
+      isClosing: false,
+      isConfirm: true,
+      message,
+      onConfirm, // 비동기 허용
+      onCancel: options?.onCancel,
+      title: options?.title || '확인창',
+      subTitle: options?.subTitle,
+      confirmText: options?.confirmText,
+      cancelText: options?.cancelText,
     })
   }
 
@@ -68,5 +98,5 @@ export const useModal = () => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [location.pathname])
 
-  return { openModal, closeModal, modalToModal } as const
+  return { openModal, openConfirm, closeModal, modalToModal } as const
 }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -20,6 +20,7 @@ import { CreateStudyGroup } from './pages/study-groups/CreateStudyGroup'
 import { StudyGroupDetail } from './pages/StudyGroupDetail'
 import { StudyRecord } from './pages/study-groups/StudyRecord/StudyRecord'
 import { StudyRecordDetail } from './pages/study-records/StudyRecordDetail'
+import { ConfirmModal } from './components/modal/confirm/ConfirmModal'
 
 const router = createBrowserRouter([
   {
@@ -93,6 +94,10 @@ const router = createBrowserRouter([
           {
             path: '/modal/schedule_detail/:studyGroupId/:scheduleId',
             Component: DetailScheduleModal,
+          },
+          {
+            path: '/modal/confirm',
+            Component: ConfirmModal,
           },
         ],
       },

--- a/src/store/storeModalOpen.ts
+++ b/src/store/storeModalOpen.ts
@@ -6,6 +6,13 @@ type ModalState = {
   title: string
   subTitle?: string
   isClosing: boolean
+
+  isConfirm?: boolean
+  message?: string
+  confirmText?: string
+  cancelText?: string
+  onConfirm?: () => void | Promise<void>
+  onCancel?: () => void
 }
 interface storeModalState {
   modalState: ModalState
@@ -20,6 +27,13 @@ const initState: ModalState = {
   title: '',
   subTitle: '',
   isClosing: false,
+
+  isConfirm: false,
+  message: '',
+  confirmText: '확인',
+  cancelText: '취소',
+  onConfirm: undefined,
+  onCancel: undefined,
 }
 
 export const storeModalOpen = create<storeModalState>((set) => ({

--- a/src/test/TestH.tsx
+++ b/src/test/TestH.tsx
@@ -1,9 +1,19 @@
-import { ReviewDetailModal } from '@/components/modal/reviewDetail/ReviewDetailModal'
+import { BasicButton } from '@/components/basicComponents/BasicButton/BasicButton'
+import { useModal } from '@/hooks/useModal'
 
 function TestH() {
+  const { openConfirm, closeModal } = useModal()
   return (
     <div>
-      <ReviewDetailModal />
+      <BasicButton
+        onClick={() =>
+          openConfirm('리더를 위임하시겠습니까?', closeModal, {
+            onCancel: closeModal,
+          })
+        }
+      >
+        확인창
+      </BasicButton>
     </div>
   )
 }

--- a/src/test/TestModal.tsx
+++ b/src/test/TestModal.tsx
@@ -5,7 +5,7 @@ import { useModal } from '@/hooks/useModal'
 const routeArr = [
   { path: '/modal/add_schedule/1', title: '새 스케줄 추가' },
   { path: '/modal/schedule_detail/1/1', title: '스케줄 상세' },
-  { path: '/modal/date_picker', title: 'date_picker' },
+  { path: '/modal/confirm', title: '확인창' },
   { path: '/modal/choosing_lecture', title: 'choosing_lecture' },
 ]
 


### PR DESCRIPTION
## 📌 제목

- feat: 확인 모달창 생성 (#100)

## 💡 개요

- 확인이 필요한 곳 어디든 사용 가능한 확인모달창 생성

## 📝 상세 내용

- useModal에 openConfirm을 추가

## 화면

<img width="404" height="265" alt="image" src="https://github.com/user-attachments/assets/15fd1cd7-672b-46b9-9887-38db0cff8fd9" />


## 사용방법

1️⃣ 기본 사용법

- 확인 메시지와 확인버튼을 클릭시 실행되는 함수를 인자로 넘겨준다.

``` tsx
import { useModal } from '@/hooks/useModal'

function MyComponent() {
  const { openConfirm } = useModal()

  const handleDelete = () => {
    openConfirm(
      '정말 삭제하시겠어요?',       // message
      async () => {                  // onConfirm (비동기 가능)
        await deleteItemAPI()
        console.log('삭제 완료!')
      }
    )
  }

  return <button onClick={handleDelete}>삭제하기</button>
}

``` 

2️⃣ 옵션 추가 (선택사항)

- 그 외의 필요한 사항은 옵션으로 3번째 인자에 객체로서 넘겨준다.

``` tsx
openConfirm(
  '이 작업은 되돌릴 수 없습니다.',
  async () => {
    await deleteItemAPI()
  },
  {
    title: '삭제 확인',           // 모달 제목
    subTitle: '삭제 시 복구 불가합니다.', // 부제목
    confirmText: '삭제',           // 확인 버튼 텍스트
    cancelText: '취소',            // 취소 버튼 텍스트
    onCancel: () => console.log('사용자가 취소함'), // 취소 시 실행할 함수
  }
)

```

## ✅ 체크리스트

- [x] 코드에 불필요한 console.log 제거
- [x] lint 검사 통과
- [ ] 테스트 통과
- [ ] 관련 문서/README 업데이트

## 🔗 관련 이슈

- close #이슈번호
