### PR TITLE
fix:보더가 피그마 디자인과 일치하도록 변경, 타입 체킹 강화

### DIFF
--- a/src/assets/dummyData/dummyStudyGroupDetail.ts
+++ b/src/assets/dummyData/dummyStudyGroupDetail.ts
@@ -1,70 +1,71 @@
-import type { StudyGroupDetail } from '@/types/StudyGroupDetailTypes';
+import type { StudyGroupDetail } from '@/types/StudyGroupDetailTypes'
 
 export const studyGroupApiResponse = {
   data: {
-    id: 1,
-    name: "React 마스터 스터디",
+    id: '1',
+    name: 'React 마스터 스터디',
     current_headcount: 4,
     max_headcount: 5,
     members: [
       {
         id: 1,
-        nickname: "김코딩",
-        is_leader: true
+        nickname: '김코딩',
+        is_leader: true,
       },
       {
         id: 2,
-        nickname: "이개발",
-        is_leader: false
+        nickname: '이개발',
+        is_leader: false,
       },
       {
         id: 3,
-        nickname: "박프론트",
-        is_leader: false
+        nickname: '박프론트',
+        is_leader: false,
       },
       {
         id: 4,
-        nickname: "최리액트",
-        is_leader: false
-      }
+        nickname: '최리액트',
+        is_leader: false,
+      },
     ],
-    profile_img_url: "https://images.unsplash.com/photo-1517694712202-14dd9538aa97?w=1200&h=300&fit=crop",
-    start_at: "2025-01-15",
-    end_at: "2025-03-15",
-    status: "ONGOING" as const,
+    profile_img_url:
+      'https://images.unsplash.com/photo-1517694712202-14dd9538aa97?w=1200&h=300&fit=crop',
+    start_at: '2025-01-15',
+    end_at: '2025-03-15',
+    status: 'ONGOING' as const,
     lectures: [
       {
-        thumbnail_img_url: "/React.svg",
-        title: "React 완벽 가이드",
-        instructor: "김멘토",
-        url_link: "https://example.com/lecture1"
+        thumbnail_img_url: '/React.svg',
+        title: 'React 완벽 가이드',
+        instructor: '김멘토',
+        url_link: 'https://example.com/lecture1',
       },
       {
-        thumbnail_img_url: "/React.svg",
-        title: "TypeScript 실전",
-        instructor: "이강사",
-        url_link: "https://example.com/lecture2"
+        thumbnail_img_url: '/React.svg',
+        title: 'TypeScript 실전',
+        instructor: '이강사',
+        url_link: 'https://example.com/lecture2',
       },
       {
-        thumbnail_img_url: "/React.svg",
-        title: "Next.js 마스터",
-        instructor: "박교수",
-        url_link: "https://example.com/lecture3"
+        thumbnail_img_url: '/React.svg',
+        title: 'Next.js 마스터',
+        instructor: '박교수',
+        url_link: 'https://example.com/lecture3',
       },
       {
-        thumbnail_img_url: "/React.svg",
-        title: "React Query 심화",
-        instructor: "최전문가",
-        url_link: "https://example.com/lecture4"
+        thumbnail_img_url: '/React.svg',
+        title: 'React Query 심화',
+        instructor: '최전문가',
+        url_link: 'https://example.com/lecture4',
       },
       {
-        thumbnail_img_url: "/React.svg",
-        title: "성능 최적화 기법",
-        instructor: "정개발자",
-        url_link: "https://example.com/lecture5"
-      }
-    ]
-  }
-};
+        thumbnail_img_url: '/React.svg',
+        title: '성능 최적화 기법',
+        instructor: '정개발자',
+        url_link: 'https://example.com/lecture5',
+      },
+    ],
+  },
+}
 
-export const studyGroupDetail: StudyGroupDetail = studyGroupApiResponse.data;
+export const studyGroupDetail: StudyGroupDetail = studyGroupApiResponse.data

--- a/src/assets/dummyData/studiesData.ts
+++ b/src/assets/dummyData/studiesData.ts
@@ -2,7 +2,7 @@ import type { StudyGroup } from '@/types/StudyGroupTypes'
 
 export const studyGroupList: StudyGroup[] = [
   {
-    id: 1,
+    id: '1',
     name: 'React 실무 프로젝트 스터디',
     status: 'ONGOING',
     start_at: '2024-04-01T09:00:00Z',
@@ -25,7 +25,7 @@ export const studyGroupList: StudyGroup[] = [
     profile_img_url: '../images/IMG-76.png',
   },
   {
-    id: 2,
+    id: '2',
     name: 'Python 데이터 분석 스터디',
     status: 'ONGOING',
     start_at: '2024-05-01T10:00:00Z',
@@ -48,7 +48,7 @@ export const studyGroupList: StudyGroup[] = [
     profile_img_url: '../images/IMG-136.png',
   },
   {
-    id: 3,
+    id: '3',
     name: 'AI 모델링 스터디',
     status: 'ONGOING',
     start_at: '2024-06-01T11:00:00Z',
@@ -71,7 +71,7 @@ export const studyGroupList: StudyGroup[] = [
     profile_img_url: '../images/IMG-206.png',
   },
   {
-    id: 4,
+    id: '4',
     name: 'Flutter 앱 개발 스터디',
     status: 'ONGOING',
     start_at: '2024-07-01T09:30:00Z',
@@ -94,7 +94,7 @@ export const studyGroupList: StudyGroup[] = [
     profile_img_url: '../images/IMG-287.png',
   },
   {
-    id: 5,
+    id: '5',
     name: 'SQL 데이터베이스 스터디',
     status: 'ONGOING',
     start_at: '2024-08-01T10:30:00Z',
@@ -118,7 +118,7 @@ export const studyGroupList: StudyGroup[] = [
   },
 
   {
-    id: 6,
+    id: '6',
     name: 'Node.js 백엔드 개발반',
     status: 'ENDED',
     start_at: '2024-03-01T09:00:00Z',
@@ -141,7 +141,7 @@ export const studyGroupList: StudyGroup[] = [
     profile_img_url: '/images/node-study.jpg',
   },
   {
-    id: 7,
+    id: '7',
     name: 'Vue.js 마스터 스터디',
     status: 'ENDED',
     start_at: '2024-02-01T10:00:00Z',
@@ -164,7 +164,7 @@ export const studyGroupList: StudyGroup[] = [
     profile_img_url: '/images/vue-study.jpg',
   },
   {
-    id: 8,
+    id: '8',
     name: 'TypeScript 심화 스터디',
     status: 'ENDED',
     start_at: '2024-01-01T11:00:00Z',

--- a/src/assets/dummyData/studyGroup.ts
+++ b/src/assets/dummyData/studyGroup.ts
@@ -1,7 +1,7 @@
 import type { StudyGroup } from '@/types/StudyGroupTypes'
 
 export const studyGroup: StudyGroup = {
-  id: 1,
+  id: '1',
   name: 'string',
   profile_img_url: 'string',
   current_headcount: 5,

--- a/src/components/basicComponents/BasicButton/BasicButton.tsx
+++ b/src/components/basicComponents/BasicButton/BasicButton.tsx
@@ -110,7 +110,7 @@ export const BasicButton = ({
   }
 
   const buttonClass = clsx(
-    'flex items-center justify-center rounded-lg font-medium transition-colors duration-150 focus-visible:ring-2 focus-visible:ring-primary-400 focus:outline-none',
+    'flex items-center cursor-pointer justify-center rounded-lg font-medium transition-colors duration-150 focus-visible:ring-2 focus-visible:ring-primary-400 focus:outline-none',
     sizeMap[size],
     colorSet.bg,
     colorSet.text,

--- a/src/components/basicComponents/basicModal/BasicModal.tsx
+++ b/src/components/basicComponents/basicModal/BasicModal.tsx
@@ -68,6 +68,12 @@ export const BasicModal = () => {
   // 렌더링할 모달 내용 선택
   const renderModalContent = () => {
     switch (modalType) {
+      case 'CONFIRM':
+        return <ConfirmModal />
+      case 'SCHEDULE':
+        return <ScheduleModal />
+      case 'DETAIL_SCHEDULE':
+        return <DetailScheduleModal />
       case 'REVIEW':
         return <ReviewModal />
       case 'REVIEW_DETAIL':
@@ -76,12 +82,6 @@ export const BasicModal = () => {
         return <DatePickerModal />
       case 'LECTURE_CHOOSING':
         return <LectureChoosingModal />
-      case 'SCHEDULE':
-        return <ScheduleModal />
-      case 'DETAIL_SCHEDULE':
-        return <DetailScheduleModal />
-      case 'CONFIRM':
-        return <ConfirmModal />
       default:
         return null
     }

--- a/src/components/basicComponents/basicModal/BasicModal.tsx
+++ b/src/components/basicComponents/basicModal/BasicModal.tsx
@@ -108,7 +108,7 @@ export const BasicModal = () => {
           transition={{ type: 'spring', stiffness: 280, damping: 25 }}
           onClick={(e) => e.stopPropagation()}
         >
-          <div className="transparent-scrollbar p-6">
+          <div className="transparent-scrollbar">
             <ModalHeader />
             {renderModalContent()}
           </div>

--- a/src/components/modal/confirm/ConfirmModal.tsx
+++ b/src/components/modal/confirm/ConfirmModal.tsx
@@ -1,41 +1,29 @@
 import { BasicButton } from '@/components/basicComponents/BasicButton/BasicButton'
+import type { ConfirmOptions } from '@/hooks/useModal'
 import { storeModalOpen } from '@/store/storeModalOpen'
 
 export const ConfirmModal = () => {
   const { modalState, closeModal } = storeModalOpen()
   const { modalType, modalProps } = modalState
 
-  if (modalType !== 'CONFIRM') return null
-  if (!modalProps) return null
+  if (modalType !== 'CONFIRM' || !modalProps) return null
 
-  const {
-    message,
-    onConfirm,
-    onCancel,
-    confirmText = '확인',
-    cancelText = '취소',
-  } = modalProps as {
-    message: string
-    onConfirm: () => void | Promise<void>
-    onCancel?: () => void
-    confirmText?: string
-    cancelText?: string
-  }
+  const props = modalProps as ConfirmOptions
 
   const handleConfirm = async () => {
-    await onConfirm?.()
+    await props.onConfirm?.()
     closeModal()
   }
 
   const handleCancel = () => {
-    onCancel?.()
+    props.onCancel?.()
     closeModal()
   }
 
   return (
     <div className="flex w-sm flex-col justify-center py-5">
       <div className="flex w-full flex-col pt-3 pb-5 text-center text-xl text-gray-900">
-        {message}
+        {props.message}
       </div>
       <div className="flex w-full justify-between gap-5 px-8 pt-5">
         <BasicButton
@@ -43,14 +31,14 @@ export const ConfirmModal = () => {
           onClick={handleCancel}
           className="w-full flex-1"
         >
-          {cancelText}
+          {props.cancelText}
         </BasicButton>
         <BasicButton
           variant="primary"
           onClick={handleConfirm}
           className="w-full flex-1"
         >
-          {confirmText}
+          {props.confirmText}
         </BasicButton>
       </div>
     </div>

--- a/src/components/modal/confirm/ConfirmModal.tsx
+++ b/src/components/modal/confirm/ConfirmModal.tsx
@@ -1,6 +1,14 @@
 import { BasicButton } from '@/components/basicComponents/BasicButton/BasicButton'
-import type { ConfirmOptions } from '@/hooks/useModal'
 import { storeModalOpen } from '@/store/storeModalOpen'
+import type { ModalPropsMap } from '@/types/Modal'
+
+// modalProps: {
+//   message: options.message,
+//   onConfirm: options.onConfirm,
+//   onCancel: options.onCancel,
+//   confirmText: options.confirmText ?? '확인',
+//   cancelText: options.cancelText ?? '취소',
+// },
 
 export const ConfirmModal = () => {
   const { modalState, closeModal } = storeModalOpen()
@@ -8,7 +16,7 @@ export const ConfirmModal = () => {
 
   if (modalType !== 'CONFIRM' || !modalProps) return null
 
-  const props = modalProps as ConfirmOptions
+  const props = modalProps as ModalPropsMap['CONFIRM']
 
   const handleConfirm = async () => {
     await props.onConfirm?.()
@@ -31,14 +39,14 @@ export const ConfirmModal = () => {
           onClick={handleCancel}
           className="w-full flex-1"
         >
-          {props.cancelText}
+          {props.cancelText ?? '취소'}
         </BasicButton>
         <BasicButton
           variant="primary"
           onClick={handleConfirm}
           className="w-full flex-1"
         >
-          {props.confirmText}
+          {props.confirmText ?? '확인'}
         </BasicButton>
       </div>
     </div>

--- a/src/components/modal/detailSchedule/DetailScheduleModal.tsx
+++ b/src/components/modal/detailSchedule/DetailScheduleModal.tsx
@@ -22,7 +22,7 @@ export const DetailScheduleModal = () => {
     if (!studyGroupId || !scheduleId) return
     modalToModal('SCHEDULE', {
       title: '스케줄 수정',
-      modalProps: { studyGroupId, scheduleId },
+      modalProps: { studyGroupId, scheduleId: Number(scheduleId) },
     })
   }
 

--- a/src/components/modal/review/ReviewModal.tsx
+++ b/src/components/modal/review/ReviewModal.tsx
@@ -25,7 +25,7 @@ const ReviewStudyBasicInfo = () => {
 export const ReviewModal = () => {
   const [rating, setRating] = useState(0)
   const [reviewInputValue, setReviewInputValue] = useState('')
-  //loader 설정시 아래 코드로 변경
+  // loader 설정시 아래 코드로 변경
   // const studyGroup = useLoaderData<StudyGroup>()
 
   const { closeModal } = useModal()

--- a/src/components/modal/reviewDetail/ReviewDetailModal.tsx
+++ b/src/components/modal/reviewDetail/ReviewDetailModal.tsx
@@ -28,7 +28,10 @@ export const ReviewDetailModal = () => {
   const handleClickPostReview = () => {
     if (isReviewed || !studyGroupId) return
 
-    modalToModal('REVIEW', { title: '리뷰 작성', modalProps: { studyGroupId } })
+    modalToModal('REVIEW', {
+      title: '리뷰 작성',
+      modalProps: { studyGroupId: studyGroupId },
+    })
   }
 
   const handleClickEditReview = () => {
@@ -38,7 +41,7 @@ export const ReviewDetailModal = () => {
     if (!studyGroupId) return
     modalToModal('REVIEW', {
       title: '리뷰 수정',
-      modalProps: { studyGroupId, reviewId: myReview.id },
+      modalProps: { studyGroupId: studyGroupId, reviewId: myReview.id },
     })
   }
 

--- a/src/components/modal/schedule/ScheduleModal.tsx
+++ b/src/components/modal/schedule/ScheduleModal.tsx
@@ -28,7 +28,7 @@ export const ScheduleModal = () => {
       if (!studyGroupId || !scheduleId) return
       modalToModal('DETAIL_SCHEDULE', {
         title: '스케줄 상세보기',
-        modalProps: { studyGroupId, scheduleId },
+        modalProps: { studyGroupId, scheduleId: Number(scheduleId) },
       })
       return
     }

--- a/src/components/studyGroup/StudyCard.tsx
+++ b/src/components/studyGroup/StudyCard.tsx
@@ -50,7 +50,7 @@ export const StudyCard = ({ study }: StudyCardProps) => {
     openModal('REVIEW_DETAIL', {
       title: '리뷰 상세',
       subTitle: study.name,
-      modalProps: { studyId: study.id },
+      modalProps: { studyGroupId: study.id },
     })
   }
 
@@ -60,7 +60,7 @@ export const StudyCard = ({ study }: StudyCardProps) => {
     setBasicStudyInfo(basicStudyInfo)
     openModal('REVIEW', {
       title: '리뷰 작성',
-      modalProps: { studyId: study.id },
+      modalProps: { studyGroupId: study.id },
     })
   }
 
@@ -70,7 +70,7 @@ export const StudyCard = ({ study }: StudyCardProps) => {
     setPreviousMyReview(myReview, basicStudyInfo)
     openModal('REVIEW', {
       title: '리뷰 수정',
-      modalProps: { studyId: study.id, reviewId: myReview.id },
+      modalProps: { studyGroupId: study.id, reviewId: myReview.id },
     })
   }
 

--- a/src/hooks/useModal.ts
+++ b/src/hooks/useModal.ts
@@ -1,43 +1,26 @@
-import { storeModalOpen, type ModalType } from '@/store/storeModalOpen'
-
-export type ConfirmOptions = {
-  title?: string
-  subTitle?: string
-  message: string
-  onConfirm: () => void | Promise<void>
-  onCancel?: () => void
-  confirmText?: string
-  cancelText?: string
-}
+import { storeModalOpen } from '@/store/storeModalOpen'
+import type { ModalPropsMap, ModalType } from '@/types/Modal'
 
 export const useModal = () => {
   const { openModal, closeModal } = storeModalOpen.getState()
 
-  const modalToModal = <T extends Record<string, unknown>>(
-    modalType: ModalType,
+  const modalToModal = <T extends ModalType>(
+    modalType: T,
     options?: {
       title?: string
       subTitle?: string
-      modalProps?: T
+      modalProps?: ModalPropsMap[T]
     }
   ) => {
     closeModal()
-    setTimeout(() => {
-      openModal(modalType, options)
-    }, 250)
+    setTimeout(() => openModal(modalType, options), 250)
   }
 
-  const openConfirm = (options: ConfirmOptions) => {
+  const openConfirm = (options: ModalPropsMap['CONFIRM']) => {
     openModal('CONFIRM', {
-      title: options.title ?? '확인',
-      subTitle: options.subTitle ?? '',
-      modalProps: {
-        message: options.message,
-        onConfirm: options.onConfirm,
-        onCancel: options.onCancel,
-        confirmText: options.confirmText ?? '확인',
-        cancelText: options.cancelText ?? '취소',
-      },
+      title: '확인',
+      subTitle: '',
+      modalProps: options,
     })
   }
 

--- a/src/hooks/useModal.ts
+++ b/src/hooks/useModal.ts
@@ -1,14 +1,14 @@
 import { storeModalOpen, type ModalType } from '@/store/storeModalOpen'
 
-type OpenConfirmFn = (options: {
+export type ConfirmOptions = {
+  title?: string
+  subTitle?: string
   message: string
   onConfirm: () => void | Promise<void>
   onCancel?: () => void
-  title?: string
-  subTitle?: string
   confirmText?: string
   cancelText?: string
-}) => void
+}
 
 export const useModal = () => {
   const { openModal, closeModal } = storeModalOpen.getState()
@@ -27,7 +27,7 @@ export const useModal = () => {
     }, 250)
   }
 
-  const openConfirm: OpenConfirmFn = (options) => {
+  const openConfirm = (options: ConfirmOptions) => {
     openModal('CONFIRM', {
       title: options.title ?? '확인',
       subTitle: options.subTitle ?? '',

--- a/src/pages/study-group-detail/StudyCalendar.tsx
+++ b/src/pages/study-group-detail/StudyCalendar.tsx
@@ -1,44 +1,44 @@
-import { useState, useEffect, useRef, useReducer } from 'react';
-import { ChevronLeft, ChevronRight } from 'lucide-react';
-import dayjs from '@/lib/dayjs';
-import { BasicButton } from '@/components/basicComponents/BasicButton/BasicButton';
-import type { Schedule } from '@/types/Schedule';
+import { useState, useEffect, useRef, useReducer } from 'react'
+import { ChevronLeft, ChevronRight } from 'lucide-react'
+import dayjs from '@/lib/dayjs'
+import { BasicButton } from '@/components/basicComponents/BasicButton/BasicButton'
+import type { Schedule } from '@/types/Schedule'
 
 interface StudyCalendarProps {
-  groupId: number;
+  groupId: string
 }
 
 type TooltipState = {
-  hoveredDay: number | null;
-  isVisible: boolean;
-};
+  hoveredDay: number | null
+  isVisible: boolean
+}
 
-type TooltipAction =
-  | { type: 'SHOW'; day: number }
-  | { type: 'HIDE' };
+type TooltipAction = { type: 'SHOW'; day: number } | { type: 'HIDE' }
 
-const tooltipReducer = (state: TooltipState, action: TooltipAction): TooltipState => {
+const tooltipReducer = (
+  state: TooltipState,
+  action: TooltipAction
+): TooltipState => {
   switch (action.type) {
     case 'SHOW':
-      return { hoveredDay: action.day, isVisible: true };
+      return { hoveredDay: action.day, isVisible: true }
     case 'HIDE':
-      return { hoveredDay: null, isVisible: false };
+      return { hoveredDay: null, isVisible: false }
     default:
-      return state;
+      return state
   }
-};
+}
 
-
-const WEEKDAYS = ['일', '월', '화', '수', '목', '금', '토'];
+const WEEKDAYS = ['일', '월', '화', '수', '목', '금', '토']
 
 export const StudyCalendar = ({ groupId }: StudyCalendarProps) => {
-  const [schedules, setSchedules] = useState<Schedule[]>([]);
-  const [currentDate, setCurrentDate] = useState(dayjs());
+  const [schedules, setSchedules] = useState<Schedule[]>([])
+  const [currentDate, setCurrentDate] = useState(dayjs())
   const [tooltipState, dispatchTooltip] = useReducer(tooltipReducer, {
     hoveredDay: null,
-    isVisible: false
-  });
-  const hoverTimeoutRef = useRef<NodeJS.Timeout | null>(null);
+    isVisible: false,
+  })
+  const hoverTimeoutRef = useRef<NodeJS.Timeout | null>(null)
 
   useEffect(() => {
     // API 호출 로직
@@ -47,7 +47,7 @@ export const StudyCalendar = ({ groupId }: StudyCalendarProps) => {
         // const response = await fetch(`/api/study-groups/${groupId}/schedules`);
         // const data = await response.json();
         // setSchedules(data.results);
-        
+
         // 임시 더미 데이터
         setSchedules([
           {
@@ -57,96 +57,104 @@ export const StudyCalendar = ({ groupId }: StudyCalendarProps) => {
             session_date: '2025-11-15',
             start_time: '14:00',
             end_time: '16:00',
-            schedule_members: []
-          }
-        ]);
+            schedule_members: [],
+          },
+        ])
       } catch (error) {
-        console.error('Failed to fetch schedules:', error);
+        console.error('Failed to fetch schedules:', error)
       }
-    };
+    }
 
-    fetchSchedules();
-  }, [groupId]);
+    fetchSchedules()
+  }, [groupId])
 
-  const handleAddSchedule = () => {return};
+  // groupId는 uuid 형식
+  const handleAddSchedule = () => {
+    return
+  }
 
   const handlePrevMonth = () => {
-    setCurrentDate(prev => prev.subtract(1, 'month'));
-  };
+    setCurrentDate((prev) => prev.subtract(1, 'month'))
+  }
 
   const handleNextMonth = () => {
-    setCurrentDate(prev => prev.add(1, 'month'));
-  };
+    setCurrentDate((prev) => prev.add(1, 'month'))
+  }
 
   const handleMouseEnter = (day: number) => {
     hoverTimeoutRef.current = setTimeout(() => {
-      dispatchTooltip({ type: 'SHOW', day });
-    }, 1000);
-  };
+      dispatchTooltip({ type: 'SHOW', day })
+    }, 1000)
+  }
 
   const handleMouseLeave = () => {
     if (hoverTimeoutRef.current) {
-      clearTimeout(hoverTimeoutRef.current);
+      clearTimeout(hoverTimeoutRef.current)
     }
-    dispatchTooltip({ type: 'HIDE' });
-  };
+    dispatchTooltip({ type: 'HIDE' })
+  }
 
   useEffect(() => {
     return () => {
       if (hoverTimeoutRef.current) {
-        clearTimeout(hoverTimeoutRef.current);
+        clearTimeout(hoverTimeoutRef.current)
       }
-    };
-  }, []);
+    }
+  }, [])
 
   const generateCalendar = () => {
-    const year = currentDate.year();
-    const month = currentDate.month();
-    const firstDayOfMonth = dayjs(new Date(year, month, 1));
-    const lastDayOfMonth = dayjs(new Date(year, month + 1, 0));
-    
-    const firstDay = firstDayOfMonth.day();
-    const daysInMonth = lastDayOfMonth.date();
+    const year = currentDate.year()
+    const month = currentDate.month()
+    const firstDayOfMonth = dayjs(new Date(year, month, 1))
+    const lastDayOfMonth = dayjs(new Date(year, month + 1, 0))
 
-    const calendar: (number | null)[][] = [];
-    let week: (number | null)[] = Array(firstDay).fill(null);
+    const firstDay = firstDayOfMonth.day()
+    const daysInMonth = lastDayOfMonth.date()
+
+    const calendar: (number | null)[][] = []
+    let week: (number | null)[] = Array(firstDay).fill(null)
 
     for (let day = 1; day <= daysInMonth; day++) {
-      week.push(day);
+      week.push(day)
       if (week.length === 7) {
-        calendar.push(week);
-        week = [];
+        calendar.push(week)
+        week = []
       }
     }
 
     if (week.length > 0) {
       while (week.length < 7) {
-        week.push(null);
+        week.push(null)
       }
-      calendar.push(week);
+      calendar.push(week)
     }
 
-    return calendar;
-  };
+    return calendar
+  }
 
   // 현재 월의 스케줄 필터링
-  const currentMonthSchedules = schedules.filter(schedule => {
-    const scheduleDate = dayjs(schedule.session_date);
-    return scheduleDate.year() === currentDate.year() && 
-           scheduleDate.month() === currentDate.month();
-  });
+  const currentMonthSchedules = schedules.filter((schedule) => {
+    const scheduleDate = dayjs(schedule.session_date)
+    return (
+      scheduleDate.year() === currentDate.year() &&
+      scheduleDate.month() === currentDate.month()
+    )
+  })
 
   // 날짜별 스케줄 맵핑
-  const schedulesByDay = currentMonthSchedules.reduce((acc, schedule) => {
-    const day = dayjs(schedule.session_date).date();
-    if (!acc[day]) acc[day] = [];
-    acc[day].push(schedule);
-    return acc;
-  }, {} as Record<number, Schedule[]>);
-  
+  const schedulesByDay = currentMonthSchedules.reduce(
+    (acc, schedule) => {
+      const day = dayjs(schedule.session_date).date()
+      if (!acc[day]) acc[day] = []
+      acc[day].push(schedule)
+      return acc
+    },
+    {} as Record<number, Schedule[]>
+  )
+
   return (
-    <div className="bg-white rounded-2xl p-6 border border-gray-100">
-      <div className="flex items-center justify-between mb-6">
+    <div className="rounded-2xl border border-gray-100 bg-white p-6">
+      <div className="mb-6 flex items-center justify-between">
         <h2 className="text-xl font-bold text-gray-900">스케줄 관리</h2>
         <BasicButton
           variant="primary"
@@ -159,97 +167,111 @@ export const StudyCalendar = ({ groupId }: StudyCalendarProps) => {
       </div>
 
       <div className="mb-4 overflow-hidden">
-        <div className="flex items-center justify-between mb-6 gap-4">
+        <div className="mb-6 flex items-center justify-between gap-4">
           <button
             onClick={handlePrevMonth}
-            className="p-1 hover:bg-gray-100 rounded transition-colors"
+            className="rounded p-1 transition-colors hover:bg-gray-100"
             aria-label="이전 달"
           >
-            <ChevronLeft className="w-5 h-5 text-gray-700" />
+            <ChevronLeft className="h-5 w-5 text-gray-700" />
           </button>
-          
-          <h3 className="text-lg font-bold text-gray-900 min-w-[120px] text-center">
+
+          <h3 className="min-w-[120px] text-center text-lg font-bold text-gray-900">
             {currentDate.format('YYYY년 M월')}
           </h3>
-          
+
           <button
             onClick={handleNextMonth}
-            className="p-1 hover:bg-gray-100 rounded transition-colors"
+            className="rounded p-1 transition-colors hover:bg-gray-100"
             aria-label="다음 달"
           >
-            <ChevronRight className="w-5 h-5 text-gray-700" />
+            <ChevronRight className="h-5 w-5 text-gray-700" />
           </button>
         </div>
 
-        <div className="grid grid-cols-7 border border-gray-200 rounded-t-lg overflow-hidden min-w-[600px]">
+        <div className="grid min-w-[600px] grid-cols-7 overflow-hidden rounded-t-lg border border-gray-200">
           {WEEKDAYS.map((day, idx) => (
             <div
               key={`weekday-${idx}`}
-              className="flex items-center justify-center text-sm font-semibold text-gray-900 bg-gray-50 border-r border-gray-200 last:border-r-0 h-11"
+              className="flex h-11 items-center justify-center border-r border-gray-200 bg-gray-50 text-sm font-semibold text-gray-900 last:border-r-0"
             >
               {day}
             </div>
           ))}
         </div>
 
-<div className="grid grid-cols-7 border border-gray-200 border-t-0 rounded-b-lg min-w-[600px]">
-  {generateCalendar().map((week, weekIdx) =>
-    week.map((day, dayIdx) => {
-      const daySchedules = day ? schedulesByDay[day] : [];
+        <div className="grid min-w-[600px] grid-cols-7 rounded-b-lg border border-t-0 border-gray-200">
+          {generateCalendar().map((week, weekIdx) =>
+            week.map((day, dayIdx) => {
+              const daySchedules = day ? schedulesByDay[day] : []
 
-      return (
-        <div
-          key={`${weekIdx}-${dayIdx}`}
-          className="relative aspect-[1/0.95] border-r border-b border-gray-200 last:border-r-0"
-        >
-          {day ? (
-            <div className="h-full bg-white hover:border-gray-300 transition-all cursor-pointer p-2">
-              <div className="text-xs text-gray-900 pb-2">{day}</div>
-
-              {daySchedules && daySchedules.map((schedule) => {
-                return(
-                <div 
-                  key={schedule.id}
-                  className="relative bg-primary-100 rounded p-1 mb-1"
-                  onMouseEnter={() => handleMouseEnter(day)}
-                  onMouseLeave={handleMouseLeave}
+              return (
+                <div
+                  key={`${weekIdx}-${dayIdx}`}
+                  className="relative aspect-[1/0.95] border-r border-b border-gray-200 last:border-r-0"
                 >
-                  <h4 className="text-[11px] text-primary-800 leading-tight line-clamp-1 mb-1">
-                    {schedule.title}
-                  </h4>
-                  <p className="text-[10px] text-primary-800/75 leading-tight">
-                    {dayjs(schedule.start_time).format('HH시mm분')} ~ {dayjs(schedule.end_time).format('HH시mm분')}
-                  </p>
+                  {day ? (
+                    <div className="h-full cursor-pointer bg-white p-2 transition-all hover:border-gray-300">
+                      <div className="pb-2 text-xs text-gray-900">{day}</div>
 
-                  {tooltipState.isVisible && tooltipState.hoveredDay === day && (
-                    <div className="absolute z-50 left-0 top-full mt-2 w-48 bg-white border border-gray-200 rounded-lg shadow-xl p-3 animate-fade-in">
-                      <div className="absolute -top-2 left-4 w-4 h-4 bg-white border-l border-t border-gray-200 transform rotate-45"></div>
-                      
-                      <div className="relative z-10 bg-white">
-                        <h4 className="text-sm font-bold text-gray-900 mb-2">
-                          {schedule.title}
-                        </h4>
-                        <div className="text-xs text-gray-600">
-                          <div className="flex items-center gap-2">
-                            <span className="font-semibold">시간:</span>
-                            <span>{dayjs(schedule.start_time).format('HH시mm분')} ~ {dayjs(schedule.end_time).format('HH시mm분')}</span>
-                          </div>
-                        </div>
-                      </div>
+                      {daySchedules &&
+                        daySchedules.map((schedule) => {
+                          return (
+                            <div
+                              key={schedule.id}
+                              className="bg-primary-100 relative mb-1 rounded p-1"
+                              onMouseEnter={() => handleMouseEnter(day)}
+                              onMouseLeave={handleMouseLeave}
+                            >
+                              <h4 className="text-primary-800 mb-1 line-clamp-1 text-[11px] leading-tight">
+                                {schedule.title}
+                              </h4>
+                              <p className="text-primary-800/75 text-[10px] leading-tight">
+                                {dayjs(schedule.start_time).format('HH시mm분')}{' '}
+                                ~ {dayjs(schedule.end_time).format('HH시mm분')}
+                              </p>
+
+                              {tooltipState.isVisible &&
+                                tooltipState.hoveredDay === day && (
+                                  <div className="animate-fade-in absolute top-full left-0 z-50 mt-2 w-48 rounded-lg border border-gray-200 bg-white p-3 shadow-xl">
+                                    <div className="absolute -top-2 left-4 h-4 w-4 rotate-45 transform border-t border-l border-gray-200 bg-white"></div>
+
+                                    <div className="relative z-10 bg-white">
+                                      <h4 className="mb-2 text-sm font-bold text-gray-900">
+                                        {schedule.title}
+                                      </h4>
+                                      <div className="text-xs text-gray-600">
+                                        <div className="flex items-center gap-2">
+                                          <span className="font-semibold">
+                                            시간:
+                                          </span>
+                                          <span>
+                                            {dayjs(schedule.start_time).format(
+                                              'HH시mm분'
+                                            )}{' '}
+                                            ~{' '}
+                                            {dayjs(schedule.end_time).format(
+                                              'HH시mm분'
+                                            )}
+                                          </span>
+                                        </div>
+                                      </div>
+                                    </div>
+                                  </div>
+                                )}
+                            </div>
+                          )
+                        })}
                     </div>
+                  ) : (
+                    <div className="h-full bg-gray-50"></div>
                   )}
                 </div>
-                ) 
-              })}
-            </div>
-          ) : (
-            <div className="h-full bg-gray-50"></div>
+              )
+            })
           )}
         </div>
-      );
-    }) 
-  )}
-</div>
-</div>
-</div>
-  )}
+      </div>
+    </div>
+  )
+}

--- a/src/pages/study-group-detail/StudyRecordList.tsx
+++ b/src/pages/study-group-detail/StudyRecordList.tsx
@@ -1,56 +1,60 @@
 // StudyRecordList.tsx
-import { useState, useEffect } from 'react';
-import { BasicButton } from '@/components/basicComponents/BasicButton/BasicButton';
-import type { StudyRecord } from '@/types/Schedule';
-import dayjs from '@/lib/dayjs';
+import { useState, useEffect } from 'react'
+import { BasicButton } from '@/components/basicComponents/BasicButton/BasicButton'
+import type { StudyRecord } from '@/types/Schedule'
+import dayjs from '@/lib/dayjs'
 
 interface StudyRecordListProps {
-  groupId: number;
+  groupId: string
 }
 
 export const StudyRecordList = ({ groupId }: StudyRecordListProps) => {
-  const [records, setRecords] = useState<StudyRecord[]>([]);
-  const [loading, setLoading] = useState(true);
+  const [records, setRecords] = useState<StudyRecord[]>([])
+  const [loading, setLoading] = useState(true)
 
   useEffect(() => {
     const fetchRecords = async () => {
       try {
         setRecords([
-          { 
+          {
             id: 1,
-            title: 'DRF 학습 정리', 
+            title: 'DRF 학습 정리',
             summary: 'DRF의 주요 구성요소 요약',
             author: { id: 7, nickname: 'oz_user' },
-            created_at: '2025-10-15T14:04:00Z'
+            created_at: '2025-10-15T14:04:00Z',
           },
-          { 
+          {
             id: 2,
-            title: 'S3 업로드 트러블슈팅', 
+            title: 'S3 업로드 트러블슈팅',
             summary: 'SignatureDoesNotMatch 오류 해결 과정',
             author: { id: 8, nickname: 'oz_user2' },
-            created_at: '2025-10-15T14:10:00Z'
+            created_at: '2025-10-15T14:10:00Z',
           },
-        ]);
+        ])
       } catch (error) {
-        console.error('Failed to fetch records:', error);
+        console.error('Failed to fetch records:', error)
       } finally {
-        setLoading(false);
+        setLoading(false)
       }
-    };
+    }
 
-    fetchRecords();
-  }, [groupId]);
+    fetchRecords()
+  }, [groupId])
 
-  const handleWriteClick = () => {};
-  const handleRecordClick = (_recordId: number) => {};
+  const handleWriteClick = () => {}
+  const handleRecordClick = (_recordId: number) => {}
 
   if (loading) {
-    return <div className="rounded-xl border border-gray-100 bg-white p-6">로딩 중...</div>;
+    return (
+      <div className="rounded-xl border border-gray-100 bg-white p-6">
+        로딩 중...
+      </div>
+    )
   }
 
   return (
     <div className="rounded-xl border border-gray-100 bg-white p-6">
-      <div className="flex items-center justify-between mb-6">
+      <div className="mb-6 flex items-center justify-between">
         <h2 className="text-xl font-bold text-gray-900">스터디 기록</h2>
         <BasicButton
           variant="primary"
@@ -58,41 +62,47 @@ export const StudyRecordList = ({ groupId }: StudyRecordListProps) => {
           className="flex items-center gap-2 !px-4 !py-2 !text-sm text-white"
           onClick={handleWriteClick}
         >
-          <img src="/icons/pen.svg" alt="write" className="w-4 h-4 filter invert brightness-0" />
+          <img
+            src="/icons/pen.svg"
+            alt="write"
+            className="h-4 w-4 brightness-0 invert filter"
+          />
           작성하기
         </BasicButton>
       </div>
 
       <div className="space-y-3">
         {records.map((record) => (
-          <div 
-            key={record.id} 
-            className="border border-gray-200 rounded-xl hover:border-primary-400 hover:bg-primary-50/40 cursor-pointer transition-all group"
+          <div
+            key={record.id}
+            className="hover:border-primary-400 hover:bg-primary-50/40 group cursor-pointer rounded-xl border border-gray-200 transition-all"
             onClick={() => handleRecordClick(record.id)}
           >
-            <div className="p-4 flex items-center justify-between">
-              <h3 className="text-gray-900 text-[28px] group-hover:text-primary-700">
+            <div className="flex items-center justify-between p-4">
+              <h3 className="group-hover:text-primary-700 text-[28px] text-gray-900">
                 {record.title}
               </h3>
-              <span className="text-xs text-gray-500 font-[14px]">
+              <span className="text-xs font-[14px] text-gray-500">
                 {dayjs(record.created_at).format('YYYY. MM. DD A HH:mm')}
               </span>
             </div>
 
-            <div className="px-4 pb-4 flex items-center gap-3">
-              <img 
-                src="/member.svg" 
-                alt={record.author.nickname} 
-                className="w-11 h-11 rounded-full object-cover" 
+            <div className="flex items-center gap-3 px-4 pb-4">
+              <img
+                src="/member.svg"
+                alt={record.author.nickname}
+                className="h-11 w-11 rounded-full object-cover"
               />
               <div className="flex-1">
-                <p className="text-sm text-gray-700">{record.author.nickname}</p>
-                  <div className='flex items-center gap-2'>
-                  <img 
-                  src="/icons/attachment.svg"  
-                  className="w-[8.5px] filter: invert-47 sepia-7 saturate-755 hue-rotate-182 brightness-90 contrast-84;" 
+                <p className="text-sm text-gray-700">
+                  {record.author.nickname}
+                </p>
+                <div className="flex items-center gap-2">
+                  <img
+                    src="/icons/attachment.svg"
+                    className="filter: contrast-84; w-[8.5px] brightness-90 hue-rotate-182 invert-47 saturate-755 sepia-7"
                   />
-                  <p className="text-xs text-gray-500 mt-1">{record.summary}</p>
+                  <p className="mt-1 text-xs text-gray-500">{record.summary}</p>
                 </div>
               </div>
             </div>
@@ -100,5 +110,5 @@ export const StudyRecordList = ({ groupId }: StudyRecordListProps) => {
         ))}
       </div>
     </div>
-  );
-};
+  )
+}

--- a/src/pages/study-group-detail/StudyRecordList.tsx
+++ b/src/pages/study-group-detail/StudyRecordList.tsx
@@ -100,6 +100,7 @@ export const StudyRecordList = ({ groupId }: StudyRecordListProps) => {
                 <div className="flex items-center gap-2">
                   <img
                     src="/icons/attachment.svg"
+                    alt="파일 첨부"
                     className="filter: contrast-84; w-[8.5px] brightness-90 hue-rotate-182 invert-47 saturate-755 sepia-7"
                   />
                   <p className="mt-1 text-xs text-gray-500">{record.summary}</p>

--- a/src/store/storeModalOpen.ts
+++ b/src/store/storeModalOpen.ts
@@ -1,31 +1,22 @@
+import type { ModalPropsMap, ModalType } from '@/types/Modal'
 import { create } from 'zustand'
 
-export type ModalType =
-  | null
-  | 'REVIEW'
-  | 'REVIEW_DETAIL'
-  | 'DATE_PICKER'
-  | 'LECTURE_CHOOSING'
-  | 'SCHEDULE'
-  | 'DETAIL_SCHEDULE'
-  | 'CONFIRM'
-
-interface ModalState {
+interface ModalState<T extends ModalType = ModalType> {
   isModalOpen: boolean
-  modalType: ModalType
+  modalType: T | null
   title?: string
   subTitle?: string
-  modalProps?: Record<string, unknown>
+  modalProps?: ModalPropsMap[T]
 }
 
 interface ModalStore {
   modalState: ModalState
-  openModal: (
-    modalType: ModalType,
+  openModal: <T extends ModalType>(
+    modalType: T,
     options?: {
       title?: string
       subTitle?: string
-      modalProps?: Record<string, unknown>
+      modalProps?: ModalPropsMap[T]
     }
   ) => void
   closeModal: () => void

--- a/src/store/storeReview.ts
+++ b/src/store/storeReview.ts
@@ -2,7 +2,7 @@ import type { Review, ReviewDetailData, ReviewForm } from '@/types/Review'
 import { create } from 'zustand'
 
 type BasicStudyInfo = {
-  id: number
+  id: string
   name: string
   start_at: string
   end_at: string

--- a/src/test/TestH.tsx
+++ b/src/test/TestH.tsx
@@ -1,20 +1,6 @@
-import { BasicButton } from '@/components/basicComponents/BasicButton/BasicButton'
-import { useModal } from '@/hooks/useModal'
-
 function TestH() {
-  const { openConfirm, closeModal } = useModal()
-
-  const options = {
-    message: '리더를 위임하시겠습니까?',
-    onConfirm: closeModal,
-    onCancel: closeModal,
-  }
-
-  return (
-    <div>
-      <BasicButton onClick={() => openConfirm(options)}>확인창</BasicButton>
-    </div>
-  )
+  // 확인창 라우팅 구조 문제로 TestModal로 이동
+  return <div></div>
 }
 
 export default TestH

--- a/src/test/TestModal.tsx
+++ b/src/test/TestModal.tsx
@@ -1,37 +1,51 @@
 import { BasicButton } from '@/components/basicComponents/BasicButton/BasicButton'
-import { useModal, type ConfirmOptions } from '@/hooks/useModal'
-import type { ModalType } from '@/store/storeModalOpen'
+import { useModal } from '@/hooks/useModal'
+import type { ModalPropsMap, ModalType } from '@/types/Modal'
 
-const modalTestList: {
-  modalType: Exclude<ModalType, null>
+type ModalTestItem<T extends ModalType> = {
+  modalType: T
   title: string
   subTitle?: string
-  modalProps?: Record<string, unknown>
-}[] = [
-  { modalType: 'SCHEDULE', title: '새 스케줄 추가' },
+  modalProps?: ModalPropsMap[T]
+}
+
+type ModalTestUnion = {
+  [K in Exclude<ModalType, null>]: ModalTestItem<K>
+}[Exclude<ModalType, null>]
+
+const modalTestList: ModalTestUnion[] = [
+  {
+    modalType: 'SCHEDULE',
+    title: '새 스케줄 추가',
+    modalProps: { studyGroupId: '1', scheduleId: 1 },
+  },
   {
     modalType: 'DETAIL_SCHEDULE',
     title: '스케줄 상세',
-    modalProps: { scheduleId: 1 },
+    modalProps: { studyGroupId: '1', scheduleId: 1 },
   },
-  { modalType: 'DATE_PICKER', title: '날짜 선택' },
+  {
+    modalType: 'DATE_PICKER',
+    title: '날짜 선택',
+    modalProps: { target: 'start' },
+  },
   { modalType: 'LECTURE_CHOOSING', title: '강의 선택' },
   {
     modalType: 'REVIEW',
     title: '리뷰 작성',
-    modalProps: { studyGroupId: 1 },
+    modalProps: { studyGroupId: '10' },
   },
   {
     modalType: 'REVIEW_DETAIL',
     title: '리뷰 상세',
-    modalProps: { studyGroupId: 1 },
+    modalProps: { studyGroupId: '10' },
   },
 ]
 
 function TestModal() {
   const { openModal, closeModal, openConfirm } = useModal()
 
-  const options: ConfirmOptions = {
+  const options = {
     message: '리더를 위임하시겠습니까?',
     onConfirm: closeModal,
     onCancel: closeModal,

--- a/src/test/TestModal.tsx
+++ b/src/test/TestModal.tsx
@@ -1,46 +1,41 @@
 import { BasicButton } from '@/components/basicComponents/BasicButton/BasicButton'
-import { useModal } from '@/hooks/useModal'
+import { useModal, type ConfirmOptions } from '@/hooks/useModal'
 import type { ModalType } from '@/store/storeModalOpen'
 
-function TestModal() {
-  const { openModal, closeModal } = useModal()
+const modalTestList: {
+  modalType: Exclude<ModalType, null>
+  title: string
+  subTitle?: string
+  modalProps?: Record<string, unknown>
+}[] = [
+  { modalType: 'SCHEDULE', title: '새 스케줄 추가' },
+  {
+    modalType: 'DETAIL_SCHEDULE',
+    title: '스케줄 상세',
+    modalProps: { scheduleId: 1 },
+  },
+  { modalType: 'DATE_PICKER', title: '날짜 선택' },
+  { modalType: 'LECTURE_CHOOSING', title: '강의 선택' },
+  {
+    modalType: 'REVIEW',
+    title: '리뷰 작성',
+    modalProps: { studyGroupId: 1 },
+  },
+  {
+    modalType: 'REVIEW_DETAIL',
+    title: '리뷰 상세',
+    modalProps: { studyGroupId: 1 },
+  },
+]
 
-  const options = {
+function TestModal() {
+  const { openModal, closeModal, openConfirm } = useModal()
+
+  const options: ConfirmOptions = {
     message: '리더를 위임하시겠습니까?',
     onConfirm: closeModal,
     onCancel: closeModal,
   }
-
-  const modalTestList: {
-    modalType: Exclude<ModalType, null>
-    title: string
-    subTitle?: string
-    modalProps?: Record<string, unknown>
-  }[] = [
-    { modalType: 'SCHEDULE', title: '새 스케줄 추가' },
-    {
-      modalType: 'DETAIL_SCHEDULE',
-      title: '스케줄 상세',
-      modalProps: { scheduleId: 1 },
-    },
-    { modalType: 'DATE_PICKER', title: '날짜 선택' },
-    { modalType: 'LECTURE_CHOOSING', title: '강의 선택' },
-    {
-      modalType: 'REVIEW',
-      title: '리뷰 작성',
-      modalProps: { studyGroupId: 1 },
-    },
-    {
-      modalType: 'REVIEW_DETAIL',
-      title: '리뷰 상세',
-      modalProps: { studyGroupId: 1 },
-    },
-    {
-      modalType: 'CONFIRM',
-      title: '확인',
-      modalProps: { options },
-    },
-  ]
 
   return (
     <div className="m-auto mt-20 flex flex-col gap-2">
@@ -58,6 +53,7 @@ function TestModal() {
           {modal.title}
         </BasicButton>
       ))}
+      <BasicButton onClick={() => openConfirm(options)}>확인창</BasicButton>
     </div>
   )
 }

--- a/src/test/TestModal.tsx
+++ b/src/test/TestModal.tsx
@@ -2,30 +2,45 @@ import { BasicButton } from '@/components/basicComponents/BasicButton/BasicButto
 import { useModal } from '@/hooks/useModal'
 import type { ModalType } from '@/store/storeModalOpen'
 
-const modalTestList: {
-  modalType: Exclude<ModalType, null>
-  title: string
-  subTitle?: string
-  modalProps?: Record<string, unknown>
-}[] = [
-  { modalType: 'SCHEDULE', title: '새 스케줄 추가' },
-  {
-    modalType: 'DETAIL_SCHEDULE',
-    title: '스케줄 상세',
-    modalProps: { scheduleId: 1 },
-  },
-  { modalType: 'DATE_PICKER', title: '날짜 선택' },
-  { modalType: 'LECTURE_CHOOSING', title: '강의 선택' },
-  { modalType: 'REVIEW', title: '리뷰 작성', modalProps: { studyGroupId: 1 } },
-  {
-    modalType: 'REVIEW_DETAIL',
-    title: '리뷰 상세',
-    modalProps: { studyGroupId: 1 },
-  },
-]
-
 function TestModal() {
-  const { openModal } = useModal()
+  const { openModal, closeModal } = useModal()
+
+  const options = {
+    message: '리더를 위임하시겠습니까?',
+    onConfirm: closeModal,
+    onCancel: closeModal,
+  }
+
+  const modalTestList: {
+    modalType: Exclude<ModalType, null>
+    title: string
+    subTitle?: string
+    modalProps?: Record<string, unknown>
+  }[] = [
+    { modalType: 'SCHEDULE', title: '새 스케줄 추가' },
+    {
+      modalType: 'DETAIL_SCHEDULE',
+      title: '스케줄 상세',
+      modalProps: { scheduleId: 1 },
+    },
+    { modalType: 'DATE_PICKER', title: '날짜 선택' },
+    { modalType: 'LECTURE_CHOOSING', title: '강의 선택' },
+    {
+      modalType: 'REVIEW',
+      title: '리뷰 작성',
+      modalProps: { studyGroupId: 1 },
+    },
+    {
+      modalType: 'REVIEW_DETAIL',
+      title: '리뷰 상세',
+      modalProps: { studyGroupId: 1 },
+    },
+    {
+      modalType: 'CONFIRM',
+      title: '확인',
+      modalProps: { options },
+    },
+  ]
 
   return (
     <div className="m-auto mt-20 flex flex-col gap-2">

--- a/src/types/Modal.ts
+++ b/src/types/Modal.ts
@@ -1,0 +1,50 @@
+export type ModalType =
+  | 'CONFIRM'
+  | 'SCHEDULE'
+  | 'DETAIL_SCHEDULE'
+  | 'REVIEW'
+  | 'REVIEW_DETAIL'
+  | 'DATE_PICKER'
+  | 'LECTURE_CHOOSING'
+
+export interface ModalPropsMap {
+  // [1] Confirm 모달
+  CONFIRM: {
+    message: string
+    onConfirm: () => void | Promise<void>
+    onCancel?: () => void
+    confirmText?: string
+    cancelText?: string
+  }
+
+  // [2] 스케줄 모달 2종 (공통 구조)
+  // studyGroupId 만 uuid
+  // 나머지는 int
+  SCHEDULE: {
+    studyGroupId: string
+    scheduleId: number
+  }
+  DETAIL_SCHEDULE: {
+    studyGroupId: string
+    scheduleId: number
+  }
+
+  // [3] 리뷰 작성/수정 모달
+  REVIEW: {
+    studyGroupId: string
+    reviewId?: number
+  }
+
+  // [4] 리뷰 상세 모달
+  REVIEW_DETAIL: {
+    studyGroupId: string
+  }
+
+  // [5] 날짜 선택 모달
+  DATE_PICKER: {
+    target: 'start' | 'end'
+  }
+
+  // 강의 선택 모달 현재 props 없음
+  LECTURE_CHOOSING: Record<string, never>
+}

--- a/src/types/Schedule.ts
+++ b/src/types/Schedule.ts
@@ -35,5 +35,5 @@ export type StudyRecordsResponse = {
   page: number
   size: number
   order: string
-  group_id: number
+  group_id: string
 }

--- a/src/types/StudyGroupDetailTypes.ts
+++ b/src/types/StudyGroupDetailTypes.ts
@@ -1,31 +1,32 @@
 export interface Member {
-  id: number;
-  nickname: string;
-  is_leader: boolean;
+  id: number
+  nickname: string
+  is_leader: boolean
 }
 
 export interface LectureDetail {
-  thumbnail_img_url: string;
-  title: string;
-  instructor: string;
-  url_link: string;
+  thumbnail_img_url: string
+  title: string
+  instructor: string
+  url_link: string
 }
 
+// 스터디 그룹만 id 값이 uuid로 들어옴
 export interface StudyGroupDetail {
-  id: number;
-  name: string;
-  current_headcount: number;
-  max_headcount: number;
-  members: Member[];
-  profile_img_url: string;
-  start_at: string;
-  end_at: string;
-  status: 'ONGOING' | 'PENDING' | 'ENDED';
-  lectures: LectureDetail[];
+  id: string
+  name: string
+  current_headcount: number
+  max_headcount: number
+  members: Member[]
+  profile_img_url: string
+  start_at: string
+  end_at: string
+  status: 'ONGOING' | 'PENDING' | 'ENDED'
+  lectures: LectureDetail[]
 }
 
 // 알아본뒤에 필요없으면 삭제 이유가 명확하면 설명 후 사용.
 // 서버에서 데이터를 감싼 형태로 보내는 경우를 위한 타입
 export interface StudyGroupDetailApiResponse {
-  data: StudyGroupDetail;
+  data: StudyGroupDetail
 }

--- a/src/types/StudyGroupTypes.ts
+++ b/src/types/StudyGroupTypes.ts
@@ -4,8 +4,9 @@ type Lectures = {
   instructor: string
 }[]
 
+// 스터디 그룹만 id 값이 uuid로 들어옴
 export type StudyGroup = {
-  id: number
+  id: string
   name: string
   profile_img_url: string
   max_headcount: number


### PR DESCRIPTION
## 💡 개요

[UI]
- 불필요하게 적용되던 p-6 속성을 제거
- 피그마와 동일한 디자인이 되도록 수정

[DATA]
- api 명세서상 프로젝트에서 사용되는 스터디 그룹 id만 유일하게 uuid 형식임
  - 이에 맞게 데이터 구조를 변경함

[LOGIC]
- 기존 모달 프롭스에서 unknown으로 타입을 지정해 사실상 ts의 이점을 사용하지 못하는 문제가 있었음
  - 모달 타입을 제네릭으로, ModalPropsMap을 사용해 각 모달에 필요한 프롭스의 타입을 지정해주도록 변경함

## 📝 상세 내용

<img width="716" height="873" alt="image" src="https://github.com/user-attachments/assets/20d48a2c-9ec4-409d-a402-fe08bb226c49" />
<img width="431" height="285" alt="image" src="https://github.com/user-attachments/assets/1dd87dbf-0ff7-4c67-a629-b4f419b1be3b" />

- 확인 모달이 정상적으로 동작함을 확인함

## ✅ 체크리스트

- [x] 코드에 불필요한 console.log 제거
- [x] lint 검사 통과
- [ ] 테스트 통과
- [ ] 관련 문서/README 업데이트

## 🔗 관련 이슈

- close #9 
