### PR TITLE
Feature/79 markdown tool

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "react-router": "^7.6.2",
         "react-spinners": "^0.17.0",
         "react-toastify": "^11.0.5",
+        "remark-breaks": "^4.0.0",
         "remark-gfm": "^4.0.1",
         "tailwindcss": "^4.1.10",
         "zustand": "^5.0.5"
@@ -4863,6 +4864,20 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/mdast-util-newline-to-break": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-newline-to-break/-/mdast-util-newline-to-break-2.0.0.tgz",
+      "integrity": "sha512-MbgeFca0hLYIEx/2zGsszCSEJJ1JSCdiY5xQxRcLDDGa8EPvlLPupJ4DSajbMPAnC0je8jfb9TiUATnxxrHUog==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-find-and-replace": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/mdast-util-phrasing": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/mdast-util-phrasing/-/mdast-util-phrasing-4.1.0.tgz",
@@ -6256,6 +6271,21 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/remark-breaks": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/remark-breaks/-/remark-breaks-4.0.0.tgz",
+      "integrity": "sha512-IjEjJOkH4FuJvHZVIW0QCDWxcG96kCq7An/KVH2NfJe6rKZU2AsHeB3OEjPNRxi4QC34Xdx7I2KGYn6IpT7gxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-newline-to-break": "^2.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/remark-gfm": {

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "react-router": "^7.6.2",
     "react-spinners": "^0.17.0",
     "react-toastify": "^11.0.5",
+    "remark-breaks": "^4.0.0",
     "remark-gfm": "^4.0.1",
     "tailwindcss": "^4.1.10",
     "zustand": "^5.0.5"

--- a/src/components/markdown/MarkdownToolbar.tsx
+++ b/src/components/markdown/MarkdownToolbar.tsx
@@ -14,7 +14,7 @@ import {
   Image as FileImage,
 } from 'lucide-react'
 
-interface MarkdownToolbarProps {
+export interface MarkdownToolbarProps {
   textareaRef: RefObject<HTMLTextAreaElement | null>
   onUpdate: Dispatch<SetStateAction<string>>
 }
@@ -116,6 +116,7 @@ export const MarkdownToolbar = ({
         className="cursor-pointer hover:text-amber-500"
         onClick={() => wrapSelectedText('`')}
       />
+
       <div className="relative">
         <FileImage
           size={18}
@@ -130,35 +131,12 @@ export const MarkdownToolbar = ({
           className="hidden"
         />
       </div>
+
       <LinkIcon
         size={18}
         className="cursor-pointer hover:text-amber-500"
-        onClick={() => {
-          const textarea = textareaRef.current
-          if (!textarea) return
-
-          const { selectionStart, selectionEnd, value } = textarea
-          const selected = value.slice(selectionStart, selectionEnd).trim()
-
-          const isUrl = /^https?:\/\/|^www\./i.test(selected)
-          const linkTarget = isUrl ? selected : 'https://'
-
-          const newValue =
-            value.slice(0, selectionStart) +
-            `[${selected || '링크텍스트'}](${linkTarget})` +
-            value.slice(selectionEnd)
-
-          onUpdate(newValue)
-
-          requestAnimationFrame(() => {
-            textarea.focus()
-            const pos = selectionStart + `[${selected || '링크텍스트'}](`.length
-            textarea.selectionStart = textarea.selectionEnd =
-              pos + linkTarget.length
-          })
-        }}
+        onClick={handleLinkInsert}
       />
-
       <Heading1
         size={18}
         className="cursor-pointer hover:text-amber-500"

--- a/src/components/markdown/MarkdownToolbar.tsx
+++ b/src/components/markdown/MarkdownToolbar.tsx
@@ -81,17 +81,31 @@ export const MarkdownToolbar = ({
   const toggleHeading = () => {
     const ta = textareaRef.current
     if (!ta) return
-    const { value, selectionStart } = ta
+    const { value, selectionStart, selectionEnd } = ta
 
-    const lineStart = value.lastIndexOf('\n', selectionStart - 1) + 1
-    const nextNewline = value.indexOf('\n', selectionStart)
-    const lineEnd = nextNewline === -1 ? value.length : nextNewline
-    const line = value.slice(lineStart, lineEnd)
+    const before = value.slice(0, selectionStart)
+    const selected = value.slice(selectionStart, selectionEnd)
+    const after = value.slice(selectionEnd)
 
-    const hasHeading = /^##\s/.test(line)
-    const newLine = hasHeading ? line.replace(/^##\s/, '') : `## ${line}`
-    const newValue = value.slice(0, lineStart) + newLine + value.slice(lineEnd)
+    const lines = selected.split('\n')
+
+    const allHaveHeading = lines.every((line) => /^##\s/.test(line))
+
+    const newLines = lines.map((line) =>
+      allHaveHeading
+        ? line.replace(/^##\s?/, '')
+        : `## ${line.replace(/^##\s?/, '')}`
+    )
+
+    const newValue = before + newLines.join('\n') + after
+
     onUpdate(newValue)
+
+    requestAnimationFrame(() => {
+      ta.focus()
+      ta.selectionStart = selectionStart
+      ta.selectionEnd = selectionStart + newLines.join('\n').length
+    })
   }
 
   const toggleList = () => {

--- a/src/components/markdown/MarkdownToolbar.tsx
+++ b/src/components/markdown/MarkdownToolbar.tsx
@@ -1,4 +1,9 @@
-import { useRef, type RefObject } from 'react'
+import {
+  useRef,
+  type RefObject,
+  type Dispatch,
+  type SetStateAction,
+} from 'react'
 import {
   Bold,
   Italic,
@@ -11,7 +16,7 @@ import {
 
 interface MarkdownToolbarProps {
   textareaRef: RefObject<HTMLTextAreaElement | null>
-  onUpdate: (newValue: string) => void
+  onUpdate: Dispatch<SetStateAction<string>>
 }
 
 export const MarkdownToolbar = ({
@@ -68,8 +73,30 @@ export const MarkdownToolbar = ({
 
     const imageURL = URL.createObjectURL(file)
     const markdownImage = `![${file.name}](${imageURL})`
+    onUpdate((prev) => prev + '\n' + markdownImage)
+  }
 
-    onUpdate((textareaRef.current?.value ?? '') + '\n' + markdownImage)
+  const handleLinkInsert = () => {
+    const textarea = textareaRef.current
+    if (!textarea) return
+
+    const { selectionStart, selectionEnd, value } = textarea
+    const selected = value.slice(selectionStart, selectionEnd).trim()
+    const isUrl = /^https?:\/\/|^www\./i.test(selected)
+    const linkTarget = isUrl ? selected : 'https://'
+
+    const newValue =
+      value.slice(0, selectionStart) +
+      `[${selected || '링크텍스트'}](${linkTarget})` +
+      value.slice(selectionEnd)
+
+    onUpdate(newValue)
+
+    requestAnimationFrame(() => {
+      textarea.focus()
+      const pos = selectionStart + `[${selected || '링크텍스트'}](`.length
+      textarea.selectionStart = textarea.selectionEnd = pos + linkTarget.length
+    })
   }
 
   return (

--- a/src/components/markdown/MarkdownToolbar.tsx
+++ b/src/components/markdown/MarkdownToolbar.tsx
@@ -91,11 +91,12 @@ export const MarkdownToolbar = ({
 
     const allHaveHeading = lines.every((line) => /^##\s/.test(line))
 
-    const newLines = lines.map((line) =>
-      allHaveHeading
+    const newLines = lines.map((line) => {
+      if (!line.trim()) return line
+      return allHaveHeading
         ? line.replace(/^##\s?/, '')
         : `## ${line.replace(/^##\s?/, '')}`
-    )
+    })
 
     const newValue = before + newLines.join('\n') + after
 

--- a/src/components/markdown/MarkdownToolbar.tsx
+++ b/src/components/markdown/MarkdownToolbar.tsx
@@ -112,16 +112,32 @@ export const MarkdownToolbar = ({
   const toggleList = () => {
     const ta = textareaRef.current
     if (!ta) return
-    const { value, selectionStart } = ta
-    const lineStart = value.lastIndexOf('\n', selectionStart - 1) + 1
-    const nextNewline = value.indexOf('\n', selectionStart)
-    const lineEnd = nextNewline === -1 ? value.length : nextNewline
-    const line = value.slice(lineStart, lineEnd)
+    const { value, selectionStart, selectionEnd } = ta
 
-    const hasList = /^-\s/.test(line)
-    const newLine = hasList ? line.replace(/^-+\s*/, '') : `- ${line}`
-    const newValue = value.slice(0, lineStart) + newLine + value.slice(lineEnd)
+    const before = value.slice(0, selectionStart)
+    const selected = value.slice(selectionStart, selectionEnd)
+    const after = value.slice(selectionEnd)
+
+    const lines = selected.split('\n')
+
+    const allHaveList = lines.every((line) => !line.trim() || /^-\s/.test(line))
+
+    const newLines = lines.map((line) => {
+      if (!line.trim()) return line
+      return allHaveList
+        ? line.replace(/^-\s?/, '')
+        : `- ${line.replace(/^-\s?/, '')}`
+    })
+
+    const newValue = before + newLines.join('\n') + after
+
     onUpdate(newValue)
+
+    requestAnimationFrame(() => {
+      ta.focus()
+      ta.selectionStart = selectionStart
+      ta.selectionEnd = selectionStart + newLines.join('\n').length
+    })
   }
 
   const handleFileSelect = (e: React.ChangeEvent<HTMLInputElement>) => {

--- a/src/components/markdown/MarkdownToolbar.tsx
+++ b/src/components/markdown/MarkdownToolbar.tsx
@@ -61,30 +61,23 @@ export const MarkdownToolbar = ({
     })
   }
 
-  const insertHeading = (level: 1 | 2 | 3 | 4 | 5 | 6 = 2) => {
+  const insertHeading = () => {
     const textarea = textareaRef.current
     if (!textarea) return
 
     const { selectionStart, selectionEnd, value } = textarea
-
     const lineStart = value.lastIndexOf('\n', selectionStart - 1) + 1
     const nextNewline = value.indexOf('\n', selectionEnd)
     const lineEnd = nextNewline === -1 ? value.length : nextNewline
 
     const line = value.slice(lineStart, lineEnd)
-
-    const headingRegex = /^(#{1,6})\s+/
+    const headingRegex = /^##\s+/
     let newLine: string
 
     if (headingRegex.test(line)) {
-      const currentLevel = (line.match(headingRegex)?.[1].length ?? 0) as number
-      if (currentLevel === level) {
-        newLine = line.replace(headingRegex, '')
-      } else {
-        newLine = line.replace(headingRegex, `${'#'.repeat(level)} `)
-      }
+      newLine = line.replace(headingRegex, '')
     } else {
-      newLine = `${'#'.repeat(level)} ${line}`
+      newLine = `## ${line}`
     }
 
     const newValue = value.slice(0, lineStart) + newLine + value.slice(lineEnd)
@@ -183,7 +176,7 @@ export const MarkdownToolbar = ({
       <Heading1
         size={18}
         className="cursor-pointer hover:text-amber-500"
-        onClick={() => insertHeading(2)}
+        onClick={insertHeading}
       />
 
       <List

--- a/src/components/markdown/MarkdownToolbar.tsx
+++ b/src/components/markdown/MarkdownToolbar.tsx
@@ -36,108 +36,94 @@ export const MarkdownToolbar = ({
     const { selectionStart: ss, selectionEnd: se, value } = ta
     const selected = value.slice(ss, se)
 
-    const before = value.slice(ss - wrapper.length, ss)
-    const after = value.slice(se, se + wrapper.length)
-    const isWrapped = before === wrapper && after === wrapper
+    const isWrapped = selected.startsWith(wrapper) && selected.endsWith(wrapper)
 
-    if (isWrapped) {
-      const newValue =
-        value.slice(0, ss - wrapper.length) +
-        selected +
-        value.slice(se + wrapper.length)
-      onUpdate(newValue)
-      requestAnimationFrame(() => {
-        ta.focus()
-        ta.selectionStart = ss - wrapper.length
-        ta.selectionEnd = se - wrapper.length
-      })
-    } else {
-      const newValue =
-        value.slice(0, ss) + wrapper + selected + wrapper + value.slice(se)
-      onUpdate(newValue)
-      requestAnimationFrame(() => {
-        ta.focus()
-        ta.selectionStart = ss + wrapper.length
-        ta.selectionEnd = se + wrapper.length
-      })
-    }
-  }
+    const newSelected = isWrapped
+      ? selected.slice(wrapper.length, selected.length - wrapper.length)
+      : `${wrapper}${selected}${wrapper}`
 
-  const toggleCode = () => {
-    const ta = textareaRef.current
-    if (!ta) return
-    const { selectionStart: ss, selectionEnd: se, value } = ta
-    const selected = value.slice(ss, se)
-    const before = value.slice(ss - 1, ss)
-    const after = value.slice(se, se + 1)
-    const isWrapped = before === '`' && after === '`'
-
-    const newValue = isWrapped
-      ? value.slice(0, ss - 1) + selected + value.slice(se + 1)
-      : value.slice(0, ss) + '`' + selected + '`' + value.slice(se)
+    const newValue = value.slice(0, ss) + newSelected + value.slice(se)
     onUpdate(newValue)
+
+    requestAnimationFrame(() => {
+      ta.focus()
+      ta.selectionStart = ss
+      ta.selectionEnd = ss + newSelected.length
+    })
   }
 
   const toggleHeading = () => {
     const ta = textareaRef.current
     if (!ta) return
-    const { value, selectionStart, selectionEnd } = ta
-
-    const before = value.slice(0, selectionStart)
-    const selected = value.slice(selectionStart, selectionEnd)
-    const after = value.slice(selectionEnd)
-
+    const { selectionStart: ss, selectionEnd: se, value } = ta
+    const selected = value.slice(ss, se)
     const lines = selected.split('\n')
-
     const allHaveHeading = lines.every((line) => /^##\s/.test(line))
 
-    const newLines = lines.map((line) => {
-      if (!line.trim()) return line
-      return allHaveHeading
-        ? line.replace(/^##\s?/, '')
-        : `## ${line.replace(/^##\s?/, '')}`
-    })
+    const newLines = lines.map((line) =>
+      !line.trim()
+        ? line
+        : allHaveHeading
+          ? line.replace(/^##\s?/, '')
+          : `## ${line.replace(/^##\s?/, '')}`
+    )
 
-    const newValue = before + newLines.join('\n') + after
-
+    const newSelected = newLines.join('\n')
+    const newValue = value.slice(0, ss) + newSelected + value.slice(se)
     onUpdate(newValue)
 
     requestAnimationFrame(() => {
       ta.focus()
-      ta.selectionStart = selectionStart
-      ta.selectionEnd = selectionStart + newLines.join('\n').length
+      ta.selectionStart = ss
+      ta.selectionEnd = ss + newSelected.length
     })
   }
 
   const toggleList = () => {
     const ta = textareaRef.current
     if (!ta) return
-    const { value, selectionStart, selectionEnd } = ta
-
-    const before = value.slice(0, selectionStart)
-    const selected = value.slice(selectionStart, selectionEnd)
-    const after = value.slice(selectionEnd)
-
+    const { selectionStart: ss, selectionEnd: se, value } = ta
+    const selected = value.slice(ss, se)
     const lines = selected.split('\n')
+    const allHaveList = lines.every((line) => /^-\s/.test(line))
 
-    const allHaveList = lines.every((line) => !line.trim() || /^-\s/.test(line))
+    const newLines = lines.map((line) =>
+      !line.trim()
+        ? line
+        : allHaveList
+          ? line.replace(/^-\s?/, '')
+          : `- ${line.replace(/^-\s?/, '')}`
+    )
 
-    const newLines = lines.map((line) => {
-      if (!line.trim()) return line
-      return allHaveList
-        ? line.replace(/^-\s?/, '')
-        : `- ${line.replace(/^-\s?/, '')}`
-    })
-
-    const newValue = before + newLines.join('\n') + after
-
+    const newSelected = newLines.join('\n')
+    const newValue = value.slice(0, ss) + newSelected + value.slice(se)
     onUpdate(newValue)
 
     requestAnimationFrame(() => {
       ta.focus()
-      ta.selectionStart = selectionStart
-      ta.selectionEnd = selectionStart + newLines.join('\n').length
+      ta.selectionStart = ss
+      ta.selectionEnd = ss + newSelected.length
     })
+  }
+
+  const toggleCode = () => toggleWrap('`')
+
+  const toggleLink = () => {
+    const ta = textareaRef.current
+    if (!ta) return
+    const { selectionStart: ss, selectionEnd: se, value } = ta
+    const selected = value.slice(ss, se)
+
+    const linkPattern = /^\[.*?\]\(.*?\)$/
+    const newValue = linkPattern.test(selected)
+      ? value.slice(0, ss) +
+        selected.replace(/^\[(.*?)\]\(.*?\)$/, '$1') +
+        value.slice(se)
+      : value.slice(0, ss) +
+        `[${selected || '링크텍스트'}](https://)` +
+        value.slice(se)
+
+    onUpdate(newValue)
   }
 
   const handleFileSelect = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -154,25 +140,6 @@ export const MarkdownToolbar = ({
     const imageURL = URL.createObjectURL(file)
     const markdownImage = `![${file.name}](${imageURL})`
     onUpdate((prev) => prev + '\n' + markdownImage)
-  }
-
-  const toggleLink = () => {
-    const ta = textareaRef.current
-    if (!ta) return
-    const { selectionStart: ss, selectionEnd: se, value } = ta
-    const selected = value.slice(ss, se)
-    const linkPattern = /^\[.*?\]\(.*?\)$/
-
-    if (linkPattern.test(selected)) {
-      const text = selected.replace(/^\[(.*?)\]\(.*?\)$/, '$1')
-      onUpdate(value.slice(0, ss) + text + value.slice(se))
-    } else {
-      const newValue =
-        value.slice(0, ss) +
-        `[${selected || '링크텍스트'}](https://)` +
-        value.slice(se)
-      onUpdate(newValue)
-    }
   }
 
   return (

--- a/src/components/markdown/MarkdownToolbar.tsx
+++ b/src/components/markdown/MarkdownToolbar.tsx
@@ -13,6 +13,11 @@ import {
   List,
   Image as FileImage,
 } from 'lucide-react'
+import {
+  ALLOWED_IMAGE_TYPES,
+  MAX_IMAGE_SIZE_BYTES,
+  UPLOAD_ERROR_MESSAGES,
+} from '@/constants/upload'
 
 export interface MarkdownToolbarProps {
   textareaRef: RefObject<HTMLTextAreaElement | null>
@@ -25,7 +30,7 @@ export const MarkdownToolbar = ({
 }: MarkdownToolbarProps) => {
   const fileInputRef = useRef<HTMLInputElement | null>(null)
 
-  const wrapSelectedText = (wrapper: string, closingWrapper?: string) => {
+  const wrapSelection = (wrapper: string, closingWrapper?: string) => {
     const textarea = textareaRef.current
     if (!textarea) return
 
@@ -61,13 +66,13 @@ export const MarkdownToolbar = ({
     const file = e.target.files?.[0]
     if (!file) return
 
-    if (!['image/png', 'image/jpeg'].includes(file.type)) {
-      alert('JPG 또는 PNG 파일만 업로드 가능합니다.')
+    if (!ALLOWED_IMAGE_TYPES.includes(file.type)) {
+      alert(UPLOAD_ERROR_MESSAGES.invalidType)
       return
     }
 
-    if (file.size > 5 * 1024 * 1024) {
-      alert('5MB 이하의 이미지만 업로드 가능합니다.')
+    if (file.size > MAX_IMAGE_SIZE_BYTES) {
+      alert(UPLOAD_ERROR_MESSAGES.tooLarge)
       return
     }
 
@@ -104,17 +109,17 @@ export const MarkdownToolbar = ({
       <Bold
         size={18}
         className="cursor-pointer hover:text-amber-500"
-        onClick={() => wrapSelectedText('**')}
+        onClick={() => wrapSelection('**')}
       />
       <Italic
         size={18}
         className="cursor-pointer hover:text-amber-500"
-        onClick={() => wrapSelectedText('*')}
+        onClick={() => wrapSelection('*')}
       />
       <Code2
         size={18}
         className="cursor-pointer hover:text-amber-500"
-        onClick={() => wrapSelectedText('`')}
+        onClick={() => wrapSelection('`')}
       />
 
       <div className="relative">
@@ -126,7 +131,7 @@ export const MarkdownToolbar = ({
         <input
           ref={fileInputRef}
           type="file"
-          accept="image/png, image/jpeg"
+          accept={ALLOWED_IMAGE_TYPES.join(',')}
           onChange={handleFileSelect}
           className="hidden"
         />
@@ -140,12 +145,12 @@ export const MarkdownToolbar = ({
       <Heading1
         size={18}
         className="cursor-pointer hover:text-amber-500"
-        onClick={() => wrapSelectedText('## ')}
+        onClick={() => wrapSelection('## ')}
       />
       <List
         size={18}
         className="cursor-pointer hover:text-amber-500"
-        onClick={() => wrapSelectedText('- ')}
+        onClick={() => wrapSelection('- ')}
       />
     </div>
   )

--- a/src/components/markdown/MarkdownToolbar.tsx
+++ b/src/components/markdown/MarkdownToolbar.tsx
@@ -30,108 +30,118 @@ export const MarkdownToolbar = ({
 }: MarkdownToolbarProps) => {
   const fileInputRef = useRef<HTMLInputElement | null>(null)
 
-  const wrapSelection = (wrapper: string, closingWrapper?: string) => {
-    const textarea = textareaRef.current
-    if (!textarea) return
-    const { selectionStart, selectionEnd, value } = textarea
-    const selected = value.slice(selectionStart, selectionEnd)
+  const toggleWrap = (wrapper: string) => {
+    const ta = textareaRef.current
+    if (!ta) return
+    const { selectionStart: ss, selectionEnd: se, value } = ta
+    const selected = value.slice(ss, se)
 
-    const newValue = closingWrapper
-      ? value.slice(0, selectionStart) +
-        wrapper +
+    const before = value.slice(ss - wrapper.length, ss)
+    const after = value.slice(se, se + wrapper.length)
+    const isWrapped = before === wrapper && after === wrapper
+
+    if (isWrapped) {
+      const newValue =
+        value.slice(0, ss - wrapper.length) +
         selected +
-        closingWrapper +
-        value.slice(selectionEnd)
-      : value.slice(0, selectionStart) +
-        wrapper +
-        selected +
-        wrapper +
-        value.slice(selectionEnd)
-
-    onUpdate(newValue)
-
-    requestAnimationFrame(() => {
-      textarea.focus()
-      const pos =
-        selectionStart +
-        wrapper.length +
-        selected.length +
-        (closingWrapper ? closingWrapper.length : wrapper.length)
-      textarea.selectionStart = textarea.selectionEnd = pos
-    })
+        value.slice(se + wrapper.length)
+      onUpdate(newValue)
+      requestAnimationFrame(() => {
+        ta.focus()
+        ta.selectionStart = ss - wrapper.length
+        ta.selectionEnd = se - wrapper.length
+      })
+    } else {
+      const newValue =
+        value.slice(0, ss) + wrapper + selected + wrapper + value.slice(se)
+      onUpdate(newValue)
+      requestAnimationFrame(() => {
+        ta.focus()
+        ta.selectionStart = ss + wrapper.length
+        ta.selectionEnd = se + wrapper.length
+      })
+    }
   }
 
-  const insertHeading = () => {
-    const textarea = textareaRef.current
-    if (!textarea) return
+  const toggleCode = () => {
+    const ta = textareaRef.current
+    if (!ta) return
+    const { selectionStart: ss, selectionEnd: se, value } = ta
+    const selected = value.slice(ss, se)
+    const before = value.slice(ss - 1, ss)
+    const after = value.slice(se, se + 1)
+    const isWrapped = before === '`' && after === '`'
 
-    const { selectionStart, selectionEnd, value } = textarea
-    const lineStart = value.lastIndexOf('\n', selectionStart - 1) + 1
-    const nextNewline = value.indexOf('\n', selectionEnd)
-    const lineEnd = nextNewline === -1 ? value.length : nextNewline
-
-    const line = value.slice(lineStart, lineEnd)
-    const headingRegex = /^##\s+/
-    let newLine: string
-
-    if (headingRegex.test(line)) {
-      newLine = line.replace(headingRegex, '')
-    } else {
-      newLine = `## ${line}`
-    }
-
-    const newValue = value.slice(0, lineStart) + newLine + value.slice(lineEnd)
-    const delta = newLine.length - line.length
-
+    const newValue = isWrapped
+      ? value.slice(0, ss - 1) + selected + value.slice(se + 1)
+      : value.slice(0, ss) + '`' + selected + '`' + value.slice(se)
     onUpdate(newValue)
+  }
 
-    requestAnimationFrame(() => {
-      textarea.focus()
-      textarea.selectionStart = selectionStart + delta
-      textarea.selectionEnd = selectionEnd + delta
-    })
+  const toggleHeading = () => {
+    const ta = textareaRef.current
+    if (!ta) return
+    const { value, selectionStart } = ta
+
+    const lineStart = value.lastIndexOf('\n', selectionStart - 1) + 1
+    const nextNewline = value.indexOf('\n', selectionStart)
+    const lineEnd = nextNewline === -1 ? value.length : nextNewline
+    const line = value.slice(lineStart, lineEnd)
+
+    const hasHeading = /^##\s/.test(line)
+    const newLine = hasHeading ? line.replace(/^##\s/, '') : `## ${line}`
+    const newValue = value.slice(0, lineStart) + newLine + value.slice(lineEnd)
+    onUpdate(newValue)
+  }
+
+  const toggleList = () => {
+    const ta = textareaRef.current
+    if (!ta) return
+    const { value, selectionStart } = ta
+    const lineStart = value.lastIndexOf('\n', selectionStart - 1) + 1
+    const nextNewline = value.indexOf('\n', selectionStart)
+    const lineEnd = nextNewline === -1 ? value.length : nextNewline
+    const line = value.slice(lineStart, lineEnd)
+
+    const hasList = /^-\s/.test(line)
+    const newLine = hasList ? line.replace(/^-+\s*/, '') : `- ${line}`
+    const newValue = value.slice(0, lineStart) + newLine + value.slice(lineEnd)
+    onUpdate(newValue)
   }
 
   const handleFileSelect = (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0]
     if (!file) return
-
     if (!ALLOWED_IMAGE_TYPES.includes(file.type)) {
       alert(UPLOAD_ERROR_MESSAGES.invalidType)
       return
     }
-
     if (file.size > MAX_IMAGE_SIZE_BYTES) {
       alert(UPLOAD_ERROR_MESSAGES.tooLarge)
       return
     }
-
     const imageURL = URL.createObjectURL(file)
     const markdownImage = `![${file.name}](${imageURL})`
     onUpdate((prev) => prev + '\n' + markdownImage)
   }
 
-  const handleLinkInsert = () => {
-    const textarea = textareaRef.current
-    if (!textarea) return
+  const toggleLink = () => {
+    const ta = textareaRef.current
+    if (!ta) return
+    const { selectionStart: ss, selectionEnd: se, value } = ta
+    const selected = value.slice(ss, se)
+    const linkPattern = /^\[.*?\]\(.*?\)$/
 
-    const { selectionStart, selectionEnd, value } = textarea
-    const selected = value.slice(selectionStart, selectionEnd).trim()
-    const isUrl = /^https?:\/\/|^www\./i.test(selected)
-    const linkTarget = isUrl ? selected : 'https://'
-
-    const newValue =
-      value.slice(0, selectionStart) +
-      `[${selected || '링크텍스트'}](${linkTarget})` +
-      value.slice(selectionEnd)
-
-    onUpdate(newValue)
-
-    requestAnimationFrame(() => {
-      textarea.focus()
-      const pos = selectionStart + `[${selected || '링크텍스트'}](`.length
-      textarea.selectionStart = textarea.selectionEnd = pos + linkTarget.length
-    })
+    if (linkPattern.test(selected)) {
+      const text = selected.replace(/^\[(.*?)\]\(.*?\)$/, '$1')
+      onUpdate(value.slice(0, ss) + text + value.slice(se))
+    } else {
+      const newValue =
+        value.slice(0, ss) +
+        `[${selected || '링크텍스트'}](https://)` +
+        value.slice(se)
+      onUpdate(newValue)
+    }
   }
 
   return (
@@ -139,19 +149,18 @@ export const MarkdownToolbar = ({
       <Bold
         size={18}
         className="cursor-pointer hover:text-amber-500"
-        onClick={() => wrapSelection('**')}
+        onClick={() => toggleWrap('**')}
       />
       <Italic
         size={18}
         className="cursor-pointer hover:text-amber-500"
-        onClick={() => wrapSelection('*')}
+        onClick={() => toggleWrap('_')}
       />
       <Code2
         size={18}
         className="cursor-pointer hover:text-amber-500"
-        onClick={() => wrapSelection('`')}
+        onClick={toggleCode}
       />
-
       <div className="relative">
         <FileImage
           size={18}
@@ -166,23 +175,20 @@ export const MarkdownToolbar = ({
           className="hidden"
         />
       </div>
-
       <LinkIcon
         size={18}
         className="cursor-pointer hover:text-amber-500"
-        onClick={handleLinkInsert}
+        onClick={toggleLink}
       />
-
       <Heading1
         size={18}
         className="cursor-pointer hover:text-amber-500"
-        onClick={insertHeading}
+        onClick={toggleHeading}
       />
-
       <List
         size={18}
         className="cursor-pointer hover:text-amber-500"
-        onClick={() => wrapSelection('- ')}
+        onClick={toggleList}
       />
     </div>
   )

--- a/src/components/markdown/MarkdownToolbar.tsx
+++ b/src/components/markdown/MarkdownToolbar.tsx
@@ -33,7 +33,6 @@ export const MarkdownToolbar = ({
   const wrapSelection = (wrapper: string, closingWrapper?: string) => {
     const textarea = textareaRef.current
     if (!textarea) return
-
     const { selectionStart, selectionEnd, value } = textarea
     const selected = value.slice(selectionStart, selectionEnd)
 
@@ -59,6 +58,44 @@ export const MarkdownToolbar = ({
         selected.length +
         (closingWrapper ? closingWrapper.length : wrapper.length)
       textarea.selectionStart = textarea.selectionEnd = pos
+    })
+  }
+
+  const insertHeading = (level: 1 | 2 | 3 | 4 | 5 | 6 = 2) => {
+    const textarea = textareaRef.current
+    if (!textarea) return
+
+    const { selectionStart, selectionEnd, value } = textarea
+
+    const lineStart = value.lastIndexOf('\n', selectionStart - 1) + 1
+    const nextNewline = value.indexOf('\n', selectionEnd)
+    const lineEnd = nextNewline === -1 ? value.length : nextNewline
+
+    const line = value.slice(lineStart, lineEnd)
+
+    const headingRegex = /^(#{1,6})\s+/
+    let newLine: string
+
+    if (headingRegex.test(line)) {
+      const currentLevel = (line.match(headingRegex)?.[1].length ?? 0) as number
+      if (currentLevel === level) {
+        newLine = line.replace(headingRegex, '')
+      } else {
+        newLine = line.replace(headingRegex, `${'#'.repeat(level)} `)
+      }
+    } else {
+      newLine = `${'#'.repeat(level)} ${line}`
+    }
+
+    const newValue = value.slice(0, lineStart) + newLine + value.slice(lineEnd)
+    const delta = newLine.length - line.length
+
+    onUpdate(newValue)
+
+    requestAnimationFrame(() => {
+      textarea.focus()
+      textarea.selectionStart = selectionStart + delta
+      textarea.selectionEnd = selectionEnd + delta
     })
   }
 
@@ -142,11 +179,13 @@ export const MarkdownToolbar = ({
         className="cursor-pointer hover:text-amber-500"
         onClick={handleLinkInsert}
       />
+
       <Heading1
         size={18}
         className="cursor-pointer hover:text-amber-500"
-        onClick={() => wrapSelection('## ')}
+        onClick={() => insertHeading(2)}
       />
+
       <List
         size={18}
         className="cursor-pointer hover:text-amber-500"

--- a/src/components/markdown/MarkdownWrite.tsx
+++ b/src/components/markdown/MarkdownWrite.tsx
@@ -7,6 +7,7 @@ import {
 } from 'react'
 import ReactMarkdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
+import remarkBreaks from 'remark-breaks'
 import { MarkdownToolbar } from './MarkdownToolbar'
 
 interface MarkdownWriteProps {
@@ -75,7 +76,7 @@ export const MarkdownWrite = ({
         <div className="min-h-[160px] bg-white p-4 text-sm text-gray-700">
           {previewValue.trim() ? (
             <ReactMarkdown
-              remarkPlugins={[remarkGfm]}
+              remarkPlugins={[remarkGfm, remarkBreaks]}
               components={{
                 h2: ({ node, ...props }) => (
                   <h2

--- a/src/components/markdown/MarkdownWrite.tsx
+++ b/src/components/markdown/MarkdownWrite.tsx
@@ -85,7 +85,7 @@ export const MarkdownWrite = ({
       <div className="border-t border-gray-200 bg-[#F9FAFB] px-4 py-2 text-xs text-gray-600">
         마크다운 문법을 사용할 수 있습니다.{` `}
         <span className="font-medium text-gray-600">
-          **굵게** _기울임_ `코드` [링크](URL) ## 제목 - 리스트
+          **굵게** _기울임_ `코드` [링크](URL) ## 제목
         </span>
       </div>
     </div>

--- a/src/components/markdown/MarkdownWrite.tsx
+++ b/src/components/markdown/MarkdownWrite.tsx
@@ -1,11 +1,17 @@
-import { useEffect, useRef, useState } from 'react'
+import {
+  useEffect,
+  useRef,
+  useState,
+  type Dispatch,
+  type SetStateAction,
+} from 'react'
 import ReactMarkdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
 import { MarkdownToolbar } from './MarkdownToolbar'
 
 interface MarkdownWriteProps {
   value: string
-  onChange: (e: React.ChangeEvent<HTMLTextAreaElement>) => void
+  onChange: Dispatch<SetStateAction<string>>
   placeholder?: string
 }
 
@@ -21,16 +27,9 @@ export const MarkdownWrite = ({
   useEffect(() => {
     const timer = setTimeout(() => {
       setPreviewValue(value)
-    }, 500)
+    }, 400)
     return () => clearTimeout(timer)
   }, [value])
-
-  const handleUpdate = (newValue: string) => {
-    const event = {
-      target: { value: newValue, name: 'description' },
-    } as unknown as React.ChangeEvent<HTMLTextAreaElement>
-    onChange(event)
-  }
 
   return (
     <div className="overflow-hidden rounded-lg border border-gray-300 bg-white">
@@ -60,7 +59,7 @@ export const MarkdownWrite = ({
           </button>
         </div>
 
-        <MarkdownToolbar textareaRef={textareaRef} onUpdate={handleUpdate} />
+        <MarkdownToolbar textareaRef={textareaRef} onUpdate={onChange} />
       </div>
 
       {tab === 'edit' ? (
@@ -68,7 +67,7 @@ export const MarkdownWrite = ({
           ref={textareaRef}
           name="description"
           value={value}
-          onChange={onChange}
+          onChange={(e) => onChange(e.target.value)}
           placeholder={placeholder}
           className="min-h-[160px] w-full resize-none bg-white p-4 text-sm text-gray-700 focus:outline-none"
         />

--- a/src/components/markdown/MarkdownWrite.tsx
+++ b/src/components/markdown/MarkdownWrite.tsx
@@ -162,7 +162,7 @@ export const MarkdownWrite = ({
       <div className="border-t border-gray-200 bg-[#F9FAFB] px-4 py-2 text-xs text-gray-600">
         마크다운 문법을 사용할 수 있습니다.{` `}
         <span className="font-medium text-gray-600">
-          **굵게** *기울임* `코드` [링크](URL) ## 제목
+          **굵게** _기울임_ `코드` [링크](URL) ## 제목
         </span>
       </div>
     </div>

--- a/src/components/markdown/MarkdownWrite.tsx
+++ b/src/components/markdown/MarkdownWrite.tsx
@@ -6,7 +6,6 @@ import {
   type SetStateAction,
 } from 'react'
 import ReactMarkdown from 'react-markdown'
-import remarkGfm from 'remark-gfm'
 import remarkBreaks from 'remark-breaks'
 import { MarkdownToolbar } from './MarkdownToolbar'
 
@@ -26,9 +25,7 @@ export const MarkdownWrite = ({
   const [previewValue, setPreviewValue] = useState(value)
 
   useEffect(() => {
-    const timer = setTimeout(() => {
-      setPreviewValue(value)
-    }, 400)
+    const timer = setTimeout(() => setPreviewValue(value), 200)
     return () => clearTimeout(timer)
   }, [value])
 
@@ -36,119 +33,45 @@ export const MarkdownWrite = ({
     <div className="overflow-hidden rounded-lg border border-gray-300 bg-white">
       <div className="flex items-center justify-between border-b border-gray-200 bg-[#F9FAFB] px-4 py-2">
         <div className="flex gap-2">
-          <button
-            type="button"
-            onClick={() => setTab('edit')}
-            className={`rounded-md px-3 py-1.5 text-sm font-medium transition ${
-              tab === 'edit'
-                ? 'bg-white text-gray-900 shadow-sm'
-                : 'text-gray-500 hover:text-gray-700'
-            }`}
-          >
-            작성
-          </button>
-          <button
-            type="button"
-            onClick={() => setTab('preview')}
-            className={`rounded-md px-3 py-1.5 text-sm font-medium transition ${
-              tab === 'preview'
-                ? 'bg-white text-gray-900 shadow-sm'
-                : 'text-gray-500 hover:text-gray-700'
-            }`}
-          >
-            미리보기
-          </button>
+          {['edit', 'preview'].map((type) => (
+            <button
+              key={type}
+              type="button"
+              onClick={() => setTab(type as 'edit' | 'preview')}
+              className={`rounded-md px-3 py-1.5 text-sm font-medium transition ${
+                tab === type
+                  ? 'bg-white text-gray-900 shadow-sm'
+                  : 'text-gray-500 hover:text-gray-700'
+              }`}
+            >
+              {type === 'edit' ? '작성' : '미리보기'}
+            </button>
+          ))}
         </div>
-
         <MarkdownToolbar textareaRef={textareaRef} onUpdate={onChange} />
       </div>
 
       {tab === 'edit' ? (
         <textarea
           ref={textareaRef}
-          name="description"
           value={value}
           onChange={(e) => onChange(e.target.value)}
           placeholder={placeholder}
-          className="min-h-[160px] w-full resize-none bg-white p-4 text-sm text-gray-700 focus:outline-none"
+          className="min-h-[180px] w-full resize-none bg-white p-4 text-sm text-gray-700 focus:outline-none"
         />
       ) : (
-        <div className="min-h-[160px] bg-white p-4 text-sm text-gray-700">
+        <div className="min-h-[180px] bg-white p-4 text-sm whitespace-pre-wrap text-gray-700">
           {previewValue.trim() ? (
             <ReactMarkdown
-              remarkPlugins={[remarkGfm, remarkBreaks]}
+              remarkPlugins={[remarkBreaks]}
               components={{
-                h2: ({ node, ...props }) => (
+                h2: ({ node: _, ...props }) => (
                   <h2
-                    className="mb-1 text-xl font-semibold text-gray-800"
                     {...props}
+                    className="my-1 text-lg font-semibold text-gray-800"
                   />
                 ),
-                a: ({ node, ...props }) => {
-                  const href = props.href?.startsWith('http')
-                    ? props.href
-                    : `https://${props.href?.replace(/^\/*/, '')}`
-                  return (
-                    <a
-                      {...props}
-                      href={href}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="text-amber-600 hover:underline"
-                    />
-                  )
-                },
-                text: ({ children }) => {
-                  const text = String(children)
-                  const urlRegex =
-                    /((?:https?:\/\/)?(?:www\.)?[a-zA-Z0-9-]+\.[a-z]{2,}(?:\/[^\s]*)?)/g
-
-                  const parts = text.split(urlRegex)
-
-                  return (
-                    <>
-                      {parts.map((part, i) => {
-                        if (urlRegex.test(part)) {
-                          const href = part.startsWith('http')
-                            ? part
-                            : `https://${part.replace(/^\/*/, '')}`
-                          return (
-                            <a
-                              key={i}
-                              href={href}
-                              target="_blank"
-                              rel="noopener noreferrer"
-                              className="text-amber-600 hover:underline"
-                            >
-                              {part}
-                            </a>
-                          )
-                        }
-                        return <span key={i}>{part}</span>
-                      })}
-                    </>
-                  )
-                },
-                img: ({ node, ...props }) => {
-                  const src = props.src ?? ''
-                  const isSafeSrc =
-                    src.startsWith('blob:') ||
-                    src.startsWith('data:') ||
-                    src.startsWith('http')
-
-                  return isSafeSrc ? (
-                    <img
-                      {...props}
-                      src={src}
-                      alt={props.alt || '이미지 미리보기'}
-                      className="max-w-full rounded-md shadow-sm"
-                    />
-                  ) : (
-                    <span className="text-sm text-gray-400">
-                      ⚠️ 유효하지 않은 이미지 경로입니다.
-                    </span>
-                  )
-                },
+                li: ({ children }) => <div>- {children}</div>,
               }}
             >
               {previewValue}
@@ -162,7 +85,7 @@ export const MarkdownWrite = ({
       <div className="border-t border-gray-200 bg-[#F9FAFB] px-4 py-2 text-xs text-gray-600">
         마크다운 문법을 사용할 수 있습니다.{` `}
         <span className="font-medium text-gray-600">
-          **굵게** _기울임_ `코드` [링크](URL) ## 제목
+          **굵게** _기울임_ `코드` [링크](URL) ## 제목 - 리스트
         </span>
       </div>
     </div>

--- a/src/components/markdown/MarkdownWrite.tsx
+++ b/src/components/markdown/MarkdownWrite.tsx
@@ -77,6 +77,12 @@ export const MarkdownWrite = ({
             <ReactMarkdown
               remarkPlugins={[remarkGfm]}
               components={{
+                h2: ({ node, ...props }) => (
+                  <h2
+                    className="mb-1 text-xl font-semibold text-gray-800"
+                    {...props}
+                  />
+                ),
                 a: ({ node, ...props }) => {
                   const href = props.href?.startsWith('http')
                     ? props.href

--- a/src/components/markdown/MarkdownWrite.tsx
+++ b/src/components/markdown/MarkdownWrite.tsx
@@ -60,7 +60,7 @@ export const MarkdownWrite = ({
           className="min-h-[180px] w-full resize-none bg-white p-4 text-sm text-gray-700 focus:outline-none"
         />
       ) : (
-        <div className="min-h-[180px] bg-white p-4 text-sm whitespace-pre-wrap text-gray-700">
+        <div className="min-h-[180px] bg-white p-4 text-sm text-gray-700">
           {previewValue.trim() ? (
             <ReactMarkdown
               remarkPlugins={[remarkBreaks]}
@@ -71,7 +71,10 @@ export const MarkdownWrite = ({
                     className="my-1 text-lg font-semibold text-gray-800"
                   />
                 ),
-                li: ({ children }) => <div>- {children}</div>,
+                ul: ({ children }) => (
+                  <ul className="list-disc pl-6 text-gray-700">{children}</ul>
+                ),
+                li: ({ children }) => <li className="ml-2">{children}</li>,
               }}
             >
               {previewValue}

--- a/src/components/studyReport/RecordMarkdownEditor.tsx
+++ b/src/components/studyReport/RecordMarkdownEditor.tsx
@@ -1,4 +1,4 @@
-import { MarkdownWrite } from '../markdown/MarkdownWrite'
+import { MarkdownWrite } from '@/components/markdown/MarkdownWrite'
 
 interface RecordMarkdownEditorProps {
   content: string

--- a/src/components/studyReport/RecordMarkdownEditor.tsx
+++ b/src/components/studyReport/RecordMarkdownEditor.tsx
@@ -16,7 +16,7 @@ export const RecordMarkdownEditor = ({
       </span>
       <MarkdownWrite
         value={content}
-        onChange={(e) => setContent(e.target.value)}
+        onChange={setContent}
         placeholder="학습한 내용을 마크다운 형식으로 작성하세요..."
       />
     </div>

--- a/src/constants/upload.ts
+++ b/src/constants/upload.ts
@@ -1,0 +1,9 @@
+export const MAX_IMAGE_SIZE_MB = 5
+export const MAX_IMAGE_SIZE_BYTES = MAX_IMAGE_SIZE_MB * 1024 * 1024
+
+export const ALLOWED_IMAGE_TYPES = ['image/png', 'image/jpeg']
+
+export const UPLOAD_ERROR_MESSAGES = {
+  invalidType: 'JPG 또는 PNG 파일만 업로드 가능합니다.',
+  tooLarge: `${MAX_IMAGE_SIZE_MB}MB 이하의 이미지만 업로드 가능합니다.`,
+}

--- a/src/pages/study-groups/CreateStudyGroup.tsx
+++ b/src/pages/study-groups/CreateStudyGroup.tsx
@@ -1,11 +1,11 @@
 import { useState, useEffect } from 'react'
 import { ArrowLeft } from 'lucide-react'
-import type { StudyGroupForm } from '../../types/StudyGroupTypes'
+import type { StudyGroupForm } from '@/types/StudyGroupTypes'
 import { BasicInfoSection } from './sections/BasicInfoSection'
 import { PeriodSection } from './sections/PeriodSection'
 import { LectureSection } from './sections/LectureSection'
-import { studyGroupFormMock } from '../../assets/dummyData/dummyStudyGroup'
-import { BasicButton } from '../../components/basicComponents/BasicButton/BasicButton'
+import { studyGroupFormMock } from '@/assets/dummyData/dummyStudyGroup'
+import { BasicButton } from '@/components/basicComponents/BasicButton/BasicButton'
 import dayjs from '@/lib/dayjs'
 import { useNavigate } from 'react-router'
 import { storeDatePicker } from '@/store/storeDatePicker'
@@ -22,9 +22,7 @@ export const CreateStudyGroup = () => {
   })
 
   const [isEdit, setIsEdit] = useState(false)
-
   const { startDate, endDate, reset } = storeDatePicker()
-
   const navigate = useNavigate()
 
   useEffect(() => {
@@ -52,6 +50,7 @@ export const CreateStudyGroup = () => {
     } else {
       alert('스터디 그룹이 생성되었습니다.')
     }
+
     setForm({
       ...form,
       startDate: dayjs(startDate).format('YYYY-MM-DD'),
@@ -67,22 +66,22 @@ export const CreateStudyGroup = () => {
 
   return (
     <div className="relative min-h-screen w-full bg-[#FAFAFA] py-10">
-      <div className="mx-auto mb-8 flex h-[96px] w-[832px] items-center gap-[16px]">
+      <div className="mx-auto mb-8 flex h-[96px] w-[832px] items-center gap-4">
         <button
           onClick={handleBack}
-          className="flex h-[40px] w-[40px] items-center justify-center rounded-full bg-[#F3F4F6] text-gray-700 transition hover:bg-[#E5E7EB]"
+          className="flex h-10 w-10 items-center justify-center rounded-full bg-gray-100 text-gray-700 transition hover:bg-gray-200"
         >
           <ArrowLeft size={20} strokeWidth={2} />
         </button>
 
-        <div className="flex flex-col justify-center pt-[2px]">
-          <h1 className="text-[24px] leading-[32px] font-bold text-gray-800">
+        <div className="flex flex-col justify-center">
+          <h1 className="text-2xl font-bold text-gray-800">
             {isEdit ? '스터디 그룹 수정' : '새 스터디 그룹 만들기'}
           </h1>
-          <p className="mt-[4px] text-[14px] leading-[20px] text-gray-500">
+          <p className="mt-1 text-sm text-gray-500">
             {isEdit
               ? '스터디 그룹 정보를 수정해주세요.'
-              : '함께 공부할 멤버들과 스터디 그룹을 시작해보세요'}
+              : '함께 공부할 멤버들과 스터디 그룹을 시작해보세요.'}
           </p>
         </div>
       </div>
@@ -108,7 +107,7 @@ export const CreateStudyGroup = () => {
           <BasicButton
             variant="outline"
             onClick={handleBack}
-            className="h-[50px] min-w-[80px] px-[25px] py-[13px] text-[14px] font-medium text-[#374151] hover:bg-[#F9FAFB]"
+            className="h-[50px] min-w-[80px] px-6 text-sm font-medium text-gray-700 hover:bg-gray-50"
           >
             취소
           </BasicButton>

--- a/src/pages/study-groups/sections/BasicInfoSection.tsx
+++ b/src/pages/study-groups/sections/BasicInfoSection.tsx
@@ -1,7 +1,7 @@
-import { BasicInput } from '../../../components/basicComponents/input/BasicInput'
-import type { StudyGroupForm } from '../../../types/StudyGroupTypes'
-import { ImageUploadBox } from '../../../components/upload/ImageUploadBox'
-import { MarkdownWrite } from '../../../components/markdown/MarkdownWrite'
+import { BasicInput } from '@/components/basicComponents/input/BasicInput'
+import type { StudyGroupForm } from '@/types/StudyGroupTypes'
+import { ImageUploadBox } from '@/components/upload/ImageUploadBox'
+import { MarkdownWrite } from '@/components/markdown/MarkdownWrite'
 
 interface BasicInfoSectionProps {
   form: StudyGroupForm
@@ -25,8 +25,9 @@ export const BasicInfoSection = ({
       <h2 className="text-lg font-semibold text-gray-700">기본 정보</h2>
 
       <div className="w-[766px]">
-        <label className="mb-1 block text-[14px] font-medium text-gray-800">
-          스터디 그룹명<span className="ml-1 text-[#EF4444]">*</span>
+        <label className="mb-1 block text-sm font-medium text-gray-800">
+          스터디 그룹명
+          <span className="text-danger-500 ml-1">*</span>
         </label>
         <BasicInput
           name="name"

--- a/src/pages/study-groups/sections/BasicInfoSection.tsx
+++ b/src/pages/study-groups/sections/BasicInfoSection.tsx
@@ -11,7 +11,11 @@ interface BasicInfoSectionProps {
   ) => void
 }
 
-export const BasicInfoSection = ({ form, setForm, handleChange }: Props) => {
+export const BasicInfoSection = ({
+  form,
+  setForm,
+  handleChange,
+}: BasicInfoSectionProps) => {
   const handleFileSelect = (file: File | null) => {
     setForm((prev) => ({ ...prev, image: file }))
   }

--- a/src/pages/study-groups/sections/BasicInfoSection.tsx
+++ b/src/pages/study-groups/sections/BasicInfoSection.tsx
@@ -3,7 +3,7 @@ import type { StudyGroupForm } from '../../../types/StudyGroupTypes'
 import { ImageUploadBox } from '../../../components/upload/ImageUploadBox'
 import { MarkdownWrite } from '../../../components/markdown/MarkdownWrite'
 
-interface Props {
+interface BasicInfoSectionProps {
   form: StudyGroupForm
   setForm: React.Dispatch<React.SetStateAction<StudyGroupForm>>
   handleChange: (
@@ -13,7 +13,7 @@ interface Props {
 
 export const BasicInfoSection = ({ form, setForm, handleChange }: Props) => {
   const handleFileSelect = (file: File | null) => {
-    setForm((prev: StudyGroupForm) => ({ ...prev, image: file }))
+    setForm((prev) => ({ ...prev, image: file }))
   }
 
   return (
@@ -39,7 +39,15 @@ export const BasicInfoSection = ({ form, setForm, handleChange }: Props) => {
         </label>
         <MarkdownWrite
           value={form.description}
-          onChange={handleChange}
+          onChange={(action) =>
+            setForm((prev) => ({
+              ...prev,
+              description:
+                typeof action === 'function'
+                  ? action(prev.description)
+                  : action,
+            }))
+          }
           placeholder="스터디 그룹에 대한 설명을 작성하세요. 마크다운 문법을 사용할 수 있습니다."
         />
       </div>

--- a/src/pages/study-groups/sections/LectureSection.tsx
+++ b/src/pages/study-groups/sections/LectureSection.tsx
@@ -1,7 +1,7 @@
 import { Book } from 'lucide-react'
-import { BasicButton } from '../../../components/basicComponents/BasicButton/BasicButton'
+import { BasicButton } from '@/components/basicComponents/BasicButton/BasicButton'
 // import type { StudyGroupForm } from '../../../types/StudyGroupTypes'
-import { useModal } from '../../../hooks/useModal'
+import { useModal } from '@/hooks/useModal'
 import { storeLecture } from '@/store/storeLecture'
 import type { Lecture } from '@/types/Lecture'
 import clsx from 'clsx'
@@ -25,10 +25,10 @@ export const LectureSection = () => {
     <section className="space-y-6">
       <div className="flex items-center justify-between">
         <div>
-          <h2 className="text-[20px] leading-[28px] font-medium text-[#111827]">
+          <h2 className="text-[20px] leading-[28px] font-medium text-gray-900">
             강의 선택
           </h2>
-          <p className="mt-[2px] text-[14px] leading-[20px] text-[#4B5563]">
+          <p className="mt-[2px] text-[14px] leading-[20px] text-gray-600">
             스터디에서 함께 공부할 강의를 선택하세요{' '}
             {previousLectureList.length > 0
               ? `(${previousLectureList.length}/5)`
@@ -55,7 +55,7 @@ export const LectureSection = () => {
       ) : (
         <div className="flex flex-col items-center justify-center py-12">
           <Book
-            className="mb-2 text-[#6B7280]"
+            className="mb-2 text-gray-500"
             style={{ width: '27px', height: '30px' }}
           />
           <p className="text-sm text-gray-600">아직 선택된 강의가 없습니다.</p>
@@ -92,7 +92,7 @@ const SelectedLectureCard = ({ lecture }: SelectedLectureCardProps) => {
         </p>
         <span
           className={clsx(
-            platform === 'inflearn' && 'bg-[#dcfce7] text-[#166534]',
+            platform === 'inflearn' && 'bg-success-100 text-success-800',
             platform === 'UDEMY' && 'bg-[#f3e8ff] text-[#6b21a8]',
             'rounded-sm px-2 py-1 text-center text-xs font-medium'
           )}

--- a/src/pages/study-groups/sections/PeriodSection.tsx
+++ b/src/pages/study-groups/sections/PeriodSection.tsx
@@ -1,8 +1,7 @@
-// import { useEffect } from 'react'
-import { useModal } from '../../../hooks/useModal'
-import { BasicInput } from '../../../components/basicComponents/input/BasicInput'
-import type { StudyGroupForm } from '../../../types/StudyGroupTypes'
-import { CustomSlider } from '../../../components/slider/CustomSlider'
+import { useModal } from '@/hooks/useModal'
+import { BasicInput } from '@/components/basicComponents/input/BasicInput'
+import type { StudyGroupForm } from '@/types/StudyGroupTypes'
+import { CustomSlider } from '@/components/slider/CustomSlider'
 import { Calendar } from 'lucide-react'
 import dayjs from '@/lib/dayjs'
 import { storeDatePicker } from '@/store/storeDatePicker'
@@ -40,7 +39,8 @@ export const PeriodSection = ({ form, setForm }: Props) => {
       <div className="flex gap-6">
         <div className="flex-1">
           <label className="mb-1 block text-sm font-medium text-gray-700">
-            스터디 시작일<span className="ml-1 text-[#EF4444]">*</span>
+            스터디 시작일
+            <span className="text-danger-500 ml-1">*</span>
           </label>
           <div className="relative">
             <BasicInput
@@ -59,7 +59,8 @@ export const PeriodSection = ({ form, setForm }: Props) => {
 
         <div className="flex-1">
           <label className="mb-1 block text-sm font-medium text-gray-700">
-            스터디 종료일<span className="ml-1 text-[#EF4444]">*</span>
+            스터디 종료일
+            <span className="text-danger-500 ml-1">*</span>
           </label>
           <div className="relative">
             <BasicInput
@@ -79,7 +80,7 @@ export const PeriodSection = ({ form, setForm }: Props) => {
 
       <div>
         <label className="mb-1 block text-sm font-medium text-gray-700">
-          최대 인원 수<span className="ml-1 text-[#EF4444]">*</span>
+          최대 인원 수<span className="text-danger-500 ml-1">*</span>
         </label>
 
         <div className="mt-3 flex items-center justify-between gap-8">

--- a/src/test/TestE.tsx
+++ b/src/test/TestE.tsx
@@ -1,4 +1,4 @@
-import CreateStudyGroup from '../pages/study-groups/CreateStudyGroup'
+import { CreateStudyGroup } from '@/pages/study-groups/CreateStudyGroup'
 
 export default function TestE() {
   // 아래줄 주석처리 후 링크 TestE 변경-생성 모드, 주석해제 후 링크 TestE 변경-수정 모드

--- a/src/test/TestE.tsx
+++ b/src/test/TestE.tsx
@@ -1,6 +1,8 @@
-import { StudyRecordDetail } from '../pages/study-records/StudyRecordDetail'
+import CreateStudyGroup from '../pages/study-groups/CreateStudyGroup'
 
 export default function TestE() {
+  // 아래줄 주석처리 후 링크 TestE 변경-생성 모드, 주석해제 후 링크 TestE 변경-수정 모드
+  // window.history.pushState({}, '', '/study-groups/edit')
   return (
     <>
       <nav className="fixed top-0 right-0 left-0 z-50 h-[65px] border-b border-gray-200 bg-white px-20">
@@ -23,8 +25,8 @@ export default function TestE() {
         </div>
       </nav>
 
-      <div className="min-h-screen bg-white pt-[65px]">
-        <StudyRecordDetail />
+      <div className="min-h-screen bg-gray-50 pt-[65px]">
+        <CreateStudyGroup />
       </div>
     </>
   )


### PR DESCRIPTION
## 📌 제목

-Feature/79 markdown tool

## 💡 개요

-[마크다운] 툴 기능 개선-1차

## 📝 상세 내용

[구현 내용]

-굵게, 기울임, 제목, 리스트 기능 구현 및 클릭(적용,해제,조합)

-기본기능-
![기본기능](https://github.com/user-attachments/assets/63a819c5-ed0f-4612-b852-acebf6b191d1)

-적용, 해제, 조합-
![적용,해제,조합](https://github.com/user-attachments/assets/370dd56e-ff68-4865-8ece-b33d356a5619)

[참고 내용]
굵게 = **
기울임 = *
같은 * 사용으로 적용/해제 꼬임
고재성 조교님과 논의 후 기울임 깃헙 에디터와 같이 _ 사용

[개선 작업]
빈 줄 무시 걸었으나 미리보기 빈 줄 없어짐. 이후 pr에 개선 예정
제목, 리스트는 조합 사용X. 이후 pr에 개선 예정

[추후 작업]
-개선 작업
-[마크다운] 툴 기능 개선-2차
코드 = 코드블록
이미지 = presignedUrl
링크 = 클릭(적용,해제)
-마크다운 모든 툴 기능 구현 후 각 분리(가독성)

## ✅ 체크리스트

- [ ] 코드에 불필요한 console.log 제거
- [ ] lint 검사 통과
- [ ] 테스트 통과
- [ ] 관련 문서/README 업데이트

## 🔗 관련 이슈

- close #79 
