### PR TITLE
feat:useQuery, params setting

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "clsx": "^2.1.1",
         "dayjs": "^1.11.18",
         "framer-motion": "^12.23.24",
-        "key-is-link": "^1.0.0",
+        "key-is-link": "^1.0.131",
         "lodash": "^4.17.21",
         "lucide-react": "^0.515.0",
         "react": "^19.1.0",
@@ -4316,9 +4316,9 @@
       }
     },
     "node_modules/key-is-link": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/key-is-link/-/key-is-link-1.0.0.tgz",
-      "integrity": "sha512-7b2g6BUwfD3Cmi0Lztc8rT3hpbat9+x0rNHBpmfCpbynSpVGYHLWrsOPPbyeNs5FrakFip7WBesexXpMdcXHoQ=="
+      "version": "1.0.131",
+      "resolved": "https://registry.npmjs.org/key-is-link/-/key-is-link-1.0.131.tgz",
+      "integrity": "sha512-8KdszsxgI9aSbVM7sI5HnBrPNj40yzi6YPqxP5quZyKjUJeMA+uJdGmDJgGoSyZquhO5/6+DTs36/tbMIJ+KMA=="
     },
     "node_modules/keyv": {
       "version": "4.5.4",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "clsx": "^2.1.1",
     "dayjs": "^1.11.18",
     "framer-motion": "^12.23.24",
-    "key-is-link": "^1.0.0",
+    "key-is-link": "^1.0.131",
     "lodash": "^4.17.21",
     "lucide-react": "^0.515.0",
     "react": "^19.1.0",

--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -6,7 +6,7 @@ import { keyIsLink } from 'key-is-link'
 import type { AxiosRequestConfig } from 'axios'
 
 // 추후 실제 주소로 교체
-export const BASE_URL = '/api'
+export const BASE_URL = 'import.meta.env.VITE_API_BASE_URL'
 export const LOGIN_PAGE_URL = '/login'
 const WEB_SOCKET_URL = '/ws'
 

--- a/src/api/httpClient.ts
+++ b/src/api/httpClient.ts
@@ -23,7 +23,6 @@ interface HttpClientConfig {
 }
 
 const NO_AUTH_URLS_SET = new Set<string>([
-  '/api/v1/auth/refresh',
   '/api/v1/lectures/categories',
   // '/api/v1/lectures' GET 의 경우 정확히 일치할때만 패스 되도록 따로 지정이 필요함
   // (로그인 전에 강의만 살펴보는 경우) => 실제로 지원하는 기능인지 확인 필요
@@ -65,6 +64,8 @@ export class HttpClient {
     // 요청 인터셉터 - 토큰 자동 삽입
     this.client.interceptors.request.use(
       (config) => {
+        // console.log({ config })
+
         // NO_AUTH_URLS_SET에 포함된 url요청은 인증회피
         const url = config.url || ''
         const isNoAuth = NO_AUTH_URLS_SET.has(url)
@@ -130,25 +131,26 @@ export class HttpClient {
     url: string,
     method: Method,
     data?: Req,
-    // 'url' | 'method' | 'data' 을 제외한 나머지는 config로 간주
-    config?: Omit<AxiosRequestConfig, 'url' | 'method' | 'data'>
-  ): Promise<Res> {
-    const upperMethod = method.toUpperCase()
-    const requestConfig: AxiosRequestConfig = {
-      url,
-      method,
-      ...config,
-    }
+    config?: AxiosRequestConfig
+  ): Promise<AxiosResponse<Res>> {
+    try {
+      const requestConfig: AxiosRequestConfig = {
+        url,
+        method,
+        data,
+        ...config,
+      }
 
-    if (paramsMethodSet.has(upperMethod)) {
-      requestConfig.params = data
-    } else {
-      requestConfig.data = data
-    }
+      // console.log(requestConfig)
 
-    const res: AxiosResponse<Res> =
-      await this.client.request<Res>(requestConfig)
-    return res.data
+      const res = await this.client.request<Res>(requestConfig)
+      return res
+    } catch (error) {
+      if (this.onError) {
+        await this.onError(error as AxiosError)
+      }
+      throw error
+    }
   }
 
   /**
@@ -159,5 +161,3 @@ export class HttpClient {
     return this.request.bind(this) as RequestExecutor
   }
 }
-
-const paramsMethodSet = new Set(['GET', 'DELETE', 'HEAD'])

--- a/src/hooks/api/queries/useQueryLecture.ts
+++ b/src/hooks/api/queries/useQueryLecture.ts
@@ -1,0 +1,19 @@
+import { api } from '@/api/api'
+import type { PageReq } from '@/types/ApiLink'
+import { queryKeys } from '../queryKeys'
+import { useQuery } from '@tanstack/react-query'
+
+// (스웨거) 강의 목록 검색, 필터링, 정렬 조회 기능 누락
+export const useQueryLecture = (params: PageReq) => {
+  return useQuery({
+    queryKey: queryKeys.lectures.list(params),
+    queryFn: () => api.v1.lectures.GET(undefined, { params }),
+  })
+}
+
+export const useQueryLectureCategories = () => {
+  return useQuery({
+    queryKey: queryKeys.lectures.categories(),
+    queryFn: () => api.v1.lectures.categories.GET,
+  })
+}

--- a/src/hooks/api/queries/useQueryStudyGroup.ts
+++ b/src/hooks/api/queries/useQueryStudyGroup.ts
@@ -1,0 +1,11 @@
+import { useQuery } from '@tanstack/react-query'
+import { queryKeys } from '../queryKeys'
+import { api } from '@/api/api'
+import type { PageReq } from '@/types/ApiLink'
+
+export const useQueryStudyGroup = (params: PageReq) => {
+  return useQuery({
+    queryKey: queryKeys.studies.groups.list(params),
+    queryFn: () => api.v1.studies.groups.GET(undefined, { params }),
+  })
+}

--- a/src/hooks/api/queries/useQueryUser.ts
+++ b/src/hooks/api/queries/useQueryUser.ts
@@ -1,0 +1,10 @@
+import { useQuery } from '@tanstack/react-query'
+import { queryKeys } from '../queryKeys'
+import { api } from '@/api/api'
+
+export const useQueryUser = () => {
+  return useQuery({
+    queryKey: queryKeys.users.me(),
+    queryFn: () => api.v1.users.me.GET,
+  })
+}

--- a/src/hooks/api/queryKeys.ts
+++ b/src/hooks/api/queryKeys.ts
@@ -1,8 +1,4 @@
-import type {
-  DifficultyEnum,
-  PlatformEnum,
-  StudyGroupStatus,
-} from '@/types/ApiLink'
+import type { PageReq } from '@/types/ApiLink'
 
 const defineQueryKey = <const T extends readonly unknown[]>(key: T) => key
 
@@ -24,14 +20,7 @@ export const queryKeys = {
   lectures: {
     all: () => defineQueryKey(['lectures']),
     lists: () => defineQueryKey(['lectures', 'list']),
-    list: (params?: {
-      page?: number
-      page_size?: number
-      search?: string
-      category?: number
-      difficulty?: DifficultyEnum
-      platform?: PlatformEnum
-    }) => defineQueryKey(['lectures', 'list', params ?? {}]),
+    list: (params: PageReq) => defineQueryKey(['lectures', 'list', params]),
     categories: () => defineQueryKey(['lectures', 'categories']),
     recommended: () => defineQueryKey(['lectures', 'recommended']),
   },
@@ -41,11 +30,8 @@ export const queryKeys = {
     groups: {
       all: () => defineQueryKey(['studies', 'groups']),
       lists: () => defineQueryKey(['studies', 'groups', 'list']),
-      list: (params?: {
-        page?: number
-        page_size?: number
-        status?: StudyGroupStatus
-      }) => defineQueryKey(['studies', 'groups', 'list', params]),
+      list: (params?: { page?: number }) =>
+        defineQueryKey(['studies', 'groups', 'list', params]),
       details: () => defineQueryKey(['studies', 'groups', 'detail']),
       detail: (groupId: number) =>
         defineQueryKey(['studies', 'groups', 'detail', groupId]),

--- a/src/test/TestG.tsx
+++ b/src/test/TestG.tsx
@@ -11,6 +11,7 @@ import { BasicButton } from '@/components/basicComponents/BasicButton/BasicButto
 //   lectures: [{ id: 1, title: 'React Hooks 마스터', instructor: '홍길동' }],
 // }
 
+// const params = { page: 1 }
 const TestG = () => {
   const handleClick = async () => {
     // try {
@@ -20,7 +21,8 @@ const TestG = () => {
     //   //   target_user_id: 333,
     //   // })
     //   // const res = await api.v1.studies.groups(444).members(555).DELETE()
-    //   const res = await api.v1.studies.groups.POST(dummyStudyGroup)
+    //   // const res = await api.v1.studies.groups.POST(dummyStudyGroup)
+    //   const res = await api.v1.studies.groups.GET(undefined, { params })
     //   console.log(res)
     // } catch (error) {
     //   console.error('API call failed:', error)

--- a/src/types/ApiLink.ts
+++ b/src/types/ApiLink.ts
@@ -124,7 +124,9 @@ type StudyReview = {
 }
 
 // ===================== Pagination =====================
-type Pagination<T> = {
+export type PageReq = { page: number }
+
+export type Pagination<T> = {
   count: number
   next: string | null
   previous: string | null
@@ -170,15 +172,9 @@ export type ApiLinks = {
     }
     lectures: {
       // (스웨거) 검색, 필터, 페이지네이션 기능 누락
+      // 임시로 페이지 옵션만 첨부
       GET: () => {
-        res: {
-          count: number
-          next: string
-          previous: string
-          results: Lecture[]
-          user_nickname: string
-          recommended_lectures: Lecture[]
-        }
+        res: Pagination<Lecture>
       }
 
       categories: {
@@ -192,7 +188,7 @@ export type ApiLinks = {
 }
 
 type GroupApi = {
-  GET: () => { res: StudyGroup[] }
+  GET: () => { res: Pagination<StudyGroup> }
   POST: (req: StudyGroupPost) => { res: BaseResponse }
 
   (group_id: number): {


### PR DESCRIPTION
## 📌 제목

- tanstack query 세팅, params를 받기 위한 기본 작업 완료

## 💡 개요

- 기존에 params의 경우 data 필드로 잘못 들어가는 문제가 있었음
- 제작한 라이브러리 측에서 인자 타입 판별을 잘못하여 벌어진 문제였음

```ts
type FuncType<Q, S, Config> = (data?: Q, config?: Config) => Promise<S> 
// 항상 이 타입을 강제하도록 변경함
```

## 📝 상세 내용

[트러블슈팅](https://www.notion.so/2a4caf5650aa80788552db1d2a2d7a01)

- params 예시

```ts
const res = await api.v1.studies.groups.GET(undefined, { params }) 
```
<img width="1016" height="173" alt="화면 캡처 2025-11-10 110637" src="https://github.com/user-attachments/assets/a2b64d09-9381-46ef-9191-3619b169330e" />

<img width="994" height="426" alt="화면 캡처 2025-11-10 110752" src="https://github.com/user-attachments/assets/b6f62a51-1abd-4465-8a7e-d4e2b6e12d6c" />

위와 같이 params 설정이 제대로 된것을 확인함


## ✅ 체크리스트

- [x] 코드에 불필요한 console.log 제거
- [x] lint 검사 통과
- [ ] 테스트 통과
- [ ] 관련 문서/README 업데이트

## 🔗 관련 이슈

- close #7 
