### PR TITLE
feat:nav bar 링크 추가

### DIFF
--- a/src/components/navBar/NavBar.tsx
+++ b/src/components/navBar/NavBar.tsx
@@ -42,7 +42,7 @@ const Logo = () => {
 const linkArr = [
   { path: 'https://learn.ozcoding.site/lecture', label: '강의 목록' },
   { path: '/', label: '스터디 그룹' },
-  { path: 'https://learn.ozcoding.site/recruit/manage', label: '구인 공고' },
+  { path: 'https://learn.ozcoding.site/recruit', label: '구인 공고' },
 ]
 
 const Links = () => {

--- a/src/components/navBar/NavBar.tsx
+++ b/src/components/navBar/NavBar.tsx
@@ -40,9 +40,9 @@ const Logo = () => {
 }
 
 const linkArr = [
-  { path: '/courses', label: '강의 목록' },
+  { path: 'https://learn.ozcoding.site/lecture', label: '강의 목록' },
   { path: '/', label: '스터디 그룹' },
-  { path: '/jobs', label: '구인 공고' },
+  { path: 'https://learn.ozcoding.site/recruit/manage', label: '구인 공고' },
 ]
 
 const Links = () => {


### PR DESCRIPTION
## 💡 개요

- 네브바 및 풋터의 링크 2개 추가 : 강의 목록, 구인 공고

## 📝 상세 내용

<img width="1648" height="652" alt="화면 캡처 2025-11-10 180140" src="https://github.com/user-attachments/assets/2ffc5f96-6372-4dc7-9e31-e71e57e06e60" />
<img width="1616" height="530" alt="화면 캡처 2025-11-10 180428" src="https://github.com/user-attachments/assets/8390a059-acc5-4f20-922e-fa7cadb84f4c" />

실제로 이동이 잘 되는것을 확인함

## ✅ 체크리스트

- [x] 코드에 불필요한 console.log 제거
- [x] lint 검사 통과
- [ ] 테스트 통과
- [ ] 관련 문서/README 업데이트

## 🔗 관련 이슈

- close #4 #7 
