### PR TITLE
feat : 토스트 기능 재작성(#106)

### DIFF
--- a/src/components/basicComponents/toast/ToastContainer.tsx
+++ b/src/components/basicComponents/toast/ToastContainer.tsx
@@ -3,13 +3,14 @@ import 'react-toastify/dist/ReactToastify.css'
 
 export const GlobalToast = () => (
   <ToastContainer
-    position="bottom-center"
-    autoClose={3000}
+    position="top-right"
+    autoClose={2000}
     hideProgressBar={false}
     newestOnTop={false}
     closeOnClick
-    pauseOnHover
+    pauseOnFocusLoss={false}
     draggable
+    pauseOnHover
     theme="light"
   />
 )

--- a/src/components/basicComponents/toast/ToastContainer.tsx
+++ b/src/components/basicComponents/toast/ToastContainer.tsx
@@ -1,0 +1,15 @@
+import { ToastContainer } from 'react-toastify'
+import 'react-toastify/dist/ReactToastify.css'
+
+export const GlobalToast = () => (
+  <ToastContainer
+    position="bottom-center"
+    autoClose={3000}
+    hideProgressBar={false}
+    newestOnTop={false}
+    closeOnClick
+    pauseOnHover
+    draggable
+    theme="light"
+  />
+)

--- a/src/components/breadcrumb/RecordBreadcrumb.tsx
+++ b/src/components/breadcrumb/RecordBreadcrumb.tsx
@@ -2,7 +2,7 @@ import { Link, useParams } from 'react-router'
 import { ChevronRight } from 'lucide-react'
 
 interface RecordBreadcrumbProps {
-  current: '작성' | '상세'
+  current: '작성' | '상세' | '수정'
   homeTo?: string
   groupsTo?: string
 }

--- a/src/components/studyReport/RecordActionButtons.tsx
+++ b/src/components/studyReport/RecordActionButtons.tsx
@@ -7,7 +7,7 @@ interface RecordActionButtonsProps {
   onSave: () => void
   studyGroupId: string
   mode?: 'create' | 'edit'
-  disabled?: boolean // 더 이상 사용하지 않지만 유지 가능
+  disabled?: boolean
 }
 
 export const RecordActionButtons = ({

--- a/src/components/studyReport/RecordActionButtons.tsx
+++ b/src/components/studyReport/RecordActionButtons.tsx
@@ -1,8 +1,11 @@
 import { BasicButton } from '../basicComponents/BasicButton/BasicButton.tsx'
+import { useModal } from '@/hooks/useModal'
+import { useNavigate } from 'react-router'
 
 interface RecordActionButtonsProps {
   onCancel: () => void
   onSave: () => void
+  studyGroupId: string
   mode?: 'create' | 'edit'
   disabled?: boolean
 }
@@ -10,12 +13,33 @@ interface RecordActionButtonsProps {
 export const RecordActionButtons = ({
   onCancel,
   onSave,
+  studyGroupId,
   mode = 'create',
   disabled = false,
 }: RecordActionButtonsProps) => {
+  const { openModal, closeModal } = useModal()
+  const navigate = useNavigate()
+
+  const handleCancel = () => {
+    openModal('CONFIRM', {
+      title: '정말 취소하시겠습니까?',
+      modalProps: {
+        message: '작성 중인 내용은 사라집니다.',
+        onConfirm: () => {
+          closeModal()
+          onCancel() // 기존 onCancel 호출
+          navigate(`/study_group_detail/${studyGroupId}`)
+        },
+        onCancel: () => {
+          closeModal()
+        },
+      },
+    })
+  }
+
   return (
     <div className="flex w-full justify-between">
-      <BasicButton variant="outline" size="large" onClick={onCancel}>
+      <BasicButton variant="outline" size="large" onClick={handleCancel}>
         취소
       </BasicButton>
 

--- a/src/components/studyReport/RecordActionButtons.tsx
+++ b/src/components/studyReport/RecordActionButtons.tsx
@@ -3,13 +3,15 @@ import { BasicButton } from '../basicComponents/BasicButton/BasicButton.tsx'
 interface RecordActionButtonsProps {
   onCancel: () => void
   onSave: () => void
-  mode: 'create' | 'edit'
+  mode?: 'create' | 'edit'
+  disabled?: boolean
 }
 
 export const RecordActionButtons = ({
   onCancel,
   onSave,
-  mode,
+  mode = 'create',
+  disabled = false,
 }: RecordActionButtonsProps) => {
   return (
     <div className="flex w-full justify-between">
@@ -17,7 +19,12 @@ export const RecordActionButtons = ({
         취소
       </BasicButton>
 
-      <BasicButton variant="secondary" size="large" onClick={onSave}>
+      <BasicButton
+        variant="secondary"
+        size="large"
+        onClick={onSave}
+        disabled={disabled}
+      >
         {mode === 'create' ? '기록 저장' : '기록 수정'}
       </BasicButton>
     </div>

--- a/src/components/studyReport/RecordActionButtons.tsx
+++ b/src/components/studyReport/RecordActionButtons.tsx
@@ -7,7 +7,7 @@ interface RecordActionButtonsProps {
   onSave: () => void
   studyGroupId: string
   mode?: 'create' | 'edit'
-  disabled?: boolean
+  disabled?: boolean // 더 이상 사용하지 않지만 유지 가능
 }
 
 export const RecordActionButtons = ({
@@ -41,6 +41,7 @@ export const RecordActionButtons = ({
         취소
       </BasicButton>
 
+      {/* 항상 클릭 가능하도록 disabled 제거 */}
       <BasicButton
         variant="secondary"
         size="large"

--- a/src/components/studyReport/RecordActionButtons.tsx
+++ b/src/components/studyReport/RecordActionButtons.tsx
@@ -7,7 +7,7 @@ interface RecordActionButtonsProps {
   onSave: () => void
   studyGroupId: string
   mode?: 'create' | 'edit'
-  disabled?: boolean // 더 이상 사용하지 않지만 유지 가능
+  disabled?: boolean
 }
 
 export const RecordActionButtons = ({
@@ -16,22 +16,21 @@ export const RecordActionButtons = ({
   studyGroupId,
   mode = 'create',
 }: RecordActionButtonsProps) => {
-  const { openModal, closeModal } = useModal()
+  const { openConfirm, closeModal } = useModal()
   const navigate = useNavigate()
 
   const handleCancel = () => {
-    openModal('CONFIRM', {
-      title: '정말 취소하시겠습니까?',
-      modalProps: {
-        message: '작성 중인 내용은 사라집니다.',
-        onConfirm: () => {
-          closeModal()
-          onCancel()
-          navigate(`/study_group_detail/${studyGroupId}`)
-        },
-        onCancel: () => {
-          closeModal()
-        },
+    openConfirm({
+      message: '정말 취소하시겠습니까?',
+      confirmText: '예',
+      cancelText: '아니오',
+      onConfirm: () => {
+        closeModal()
+        onCancel()
+        navigate(`/study_group_detail/${studyGroupId}`)
+      },
+      onCancel: () => {
+        closeModal()
       },
     })
   }
@@ -42,7 +41,6 @@ export const RecordActionButtons = ({
         취소
       </BasicButton>
 
-      {/* 항상 클릭 가능하도록 disabled 제거 */}
       <BasicButton
         variant="secondary"
         size="large"

--- a/src/components/studyReport/RecordActionButtons.tsx
+++ b/src/components/studyReport/RecordActionButtons.tsx
@@ -7,7 +7,7 @@ interface RecordActionButtonsProps {
   onSave: () => void
   studyGroupId: string
   mode?: 'create' | 'edit'
-  disabled?: boolean
+  disabled?: boolean // 더 이상 사용하지 않지만 유지 가능
 }
 
 export const RecordActionButtons = ({
@@ -15,7 +15,6 @@ export const RecordActionButtons = ({
   onSave,
   studyGroupId,
   mode = 'create',
-  disabled = false,
 }: RecordActionButtonsProps) => {
   const { openModal, closeModal } = useModal()
   const navigate = useNavigate()
@@ -43,12 +42,12 @@ export const RecordActionButtons = ({
         취소
       </BasicButton>
 
+      {/* 항상 클릭 가능하도록 disabled 제거 */}
       <BasicButton
         variant="secondary"
         size="large"
         onClick={onSave}
-        disabled={disabled}
-        className="disabled:cursor-not-allowed"
+        className="cursor-pointer"
       >
         {mode === 'create' ? '기록 저장' : '기록 수정'}
       </BasicButton>

--- a/src/components/studyReport/RecordActionButtons.tsx
+++ b/src/components/studyReport/RecordActionButtons.tsx
@@ -27,7 +27,7 @@ export const RecordActionButtons = ({
         message: '작성 중인 내용은 사라집니다.',
         onConfirm: () => {
           closeModal()
-          onCancel() // 기존 onCancel 호출
+          onCancel()
           navigate(`/study_group_detail/${studyGroupId}`)
         },
         onCancel: () => {
@@ -48,6 +48,7 @@ export const RecordActionButtons = ({
         size="large"
         onClick={onSave}
         disabled={disabled}
+        className="disabled:cursor-not-allowed"
       >
         {mode === 'create' ? '기록 저장' : '기록 수정'}
       </BasicButton>

--- a/src/components/studyReport/RecordFileUpload.tsx
+++ b/src/components/studyReport/RecordFileUpload.tsx
@@ -11,7 +11,7 @@ import {
 } from 'lucide-react'
 import 'react-toastify/dist/ReactToastify.css'
 import { GlobalToast } from '@/components/basicComponents/toast/ToastContainer'
-import { toast } from 'react-toastify' // 추가
+import { toast } from 'react-toastify'
 
 interface RecordFileUploadProps {
   files: File[]

--- a/src/components/studyReport/RecordFileUpload.tsx
+++ b/src/components/studyReport/RecordFileUpload.tsx
@@ -1,50 +1,171 @@
+import { useState, useRef } from 'react'
+import type { DragEvent, ChangeEvent } from 'react'
+import {
+  FileText,
+  Image,
+  Video,
+  Music,
+  File as FileIcon,
+  X,
+  Paperclip,
+} from 'lucide-react'
+import 'react-toastify/dist/ReactToastify.css'
+import { GlobalToast } from '@/components/basicComponents/toast/ToastContainer'
+import { toast } from 'react-toastify' // 추가
+
 interface RecordFileUploadProps {
-  file: File | null
-  onFileChange: (e: React.ChangeEvent<HTMLInputElement>) => void
+  files: File[]
+  onFilesChange: (files: File[]) => void
 }
 
+const MAX_TOTAL_SIZE = 10 * 1024 * 1024 // 10MB
+
 export const RecordFileUpload = ({
-  file,
-  onFileChange,
+  files,
+  onFilesChange,
 }: RecordFileUploadProps) => {
-  const handleClick = () => {
-    const fileInput = document.getElementById('fileInput') as HTMLInputElement
-    fileInput?.click()
+  const [dragActive, setDragActive] = useState(false)
+  const inputRef = useRef<HTMLInputElement | null>(null)
+
+  // 파일 선택 (클릭)
+  const handleFileSelect = (e: ChangeEvent<HTMLInputElement>) => {
+    const selected = e.target.files ? Array.from(e.target.files) : []
+    const totalSize =
+      selected.reduce((acc, f) => acc + f.size, 0) +
+      files.reduce((acc, f) => acc + f.size, 0)
+    if (totalSize > MAX_TOTAL_SIZE) {
+      toast.error('총 파일 용량이 10MB를 초과했습니다.')
+      return
+    }
+    onFilesChange([...files, ...selected])
+    toast.success(`${selected.length}개의 파일이 추가되었습니다.`)
+  }
+
+  // 드래그 앤 드롭
+  const handleDrop = (e: DragEvent<HTMLDivElement>) => {
+    e.preventDefault()
+    e.stopPropagation()
+    setDragActive(false)
+    const dropped = Array.from(e.dataTransfer.files)
+    const totalSize =
+      dropped.reduce((acc, f) => acc + f.size, 0) +
+      files.reduce((acc, f) => acc + f.size, 0)
+    if (totalSize > MAX_TOTAL_SIZE) {
+      toast.error('총 파일 용량이 10MB를 초과했습니다.')
+      return
+    }
+    onFilesChange([...files, ...dropped])
+    toast.success(`${dropped.length}개의 파일이 추가되었습니다.`)
+  }
+
+  const handleRemoveFile = (name: string) => {
+    onFilesChange(files.filter((f) => f.name !== name))
+    toast.info(`파일 "${name}"이 삭제되었습니다.`)
+  }
+
+  const getFileIcon = (file: File) => {
+    const type = file.type
+    const ext = file.name.split('.').pop()?.toLowerCase()
+
+    if (type.startsWith('image/'))
+      return <Image className="text-gray-500" size={18} />
+    if (type.startsWith('video/'))
+      return <Video className="text-gray-500" size={18} />
+    if (type.startsWith('audio/'))
+      return <Music className="text-gray-500" size={18} />
+
+    switch (ext) {
+      case 'pdf':
+      case 'doc':
+      case 'docx':
+      case 'xls':
+      case 'xlsx':
+      case 'ppt':
+      case 'pptx':
+      case 'txt':
+        return <FileText className="text-gray-500" size={18} />
+      default:
+        return <FileIcon className="text-gray-500" size={18} />
+    }
   }
 
   return (
     <div>
       <label className="mb-2 block font-semibold">첨부 파일</label>
-      <div className="rounded-xl border-2 border-dashed border-[#E5E7EB] py-10 text-center">
-        <span
-          className="flex cursor-pointer flex-col items-center gap-2 text-gray-500"
-          onClick={handleClick}
-        >
-          <img
-            src="../../public/icons/Vector@2x.png"
-            alt="파일 업로드"
-            className="h-10 w-10"
-          />
-          <span>
-            파일을 여기에 드래그하거나{' '}
-            <span className="text-yellow-600">클릭하여 선택</span>
-          </span>
-          <input
-            id="fileInput"
-            type="file"
-            className="hidden"
-            onChange={onFileChange}
-          />
-          {file && (
-            <p className="mt-2 text-sm text-gray-700">
-              선택된 파일: {file.name}
-            </p>
-          )}
-        </span>
+
+      {/* 업로드 영역 */}
+      <div
+        className={`cursor-pointer rounded-xl border-2 border-dashed py-10 text-center transition-colors ${
+          dragActive
+            ? 'border-yellow-500 bg-yellow-50'
+            : 'border-gray-200 bg-white'
+        }`}
+        onDragOver={(e) => {
+          e.preventDefault()
+          setDragActive(true)
+        }}
+        onDragLeave={(e) => {
+          e.preventDefault()
+          setDragActive(false)
+        }}
+        onDrop={handleDrop}
+        onClick={() => inputRef.current?.click()}
+      >
+        <img
+          src="/icons/Vector@2x.png"
+          alt="파일 업로드"
+          className="mx-auto mb-3 h-10 w-10 opacity-70"
+        />
+        <p className="text-gray-500">
+          파일을 여기에 드래그하거나{' '}
+          <span className="font-semibold text-yellow-600">클릭하여 선택</span>
+        </p>
         <p className="mt-2 text-xs text-gray-400">
           모든 파일 형식 지원 (최대 10MB)
         </p>
+        <input
+          ref={inputRef}
+          type="file"
+          multiple
+          className="hidden"
+          onChange={handleFileSelect}
+        />
       </div>
+
+      {/* 파일 리스트 */}
+      {files.length > 0 && (
+        <div className="mt-5 rounded-lg border border-gray-200 bg-gray-50 p-4">
+          <div className="mb-3 flex items-center gap-2 font-medium">
+            <Paperclip className="text-gray-700" size={16} />
+            첨부 파일 ({files.length}개)
+          </div>
+
+          <div className="grid gap-2 sm:grid-cols-2">
+            {files.map((file) => (
+              <div
+                key={file.name}
+                className="flex items-center justify-between rounded-lg border border-gray-200 bg-white px-4 py-3 shadow-sm hover:shadow"
+              >
+                <div className="flex min-w-0 items-center gap-2 text-sm text-gray-700">
+                  {getFileIcon(file)}
+                  <span className="max-w-[180px] truncate overflow-hidden whitespace-nowrap">
+                    {file.name}
+                  </span>
+                </div>
+                <button
+                  onClick={() => handleRemoveFile(file.name)}
+                  className="cursor-pointer text-gray-400 hover:text-gray-600"
+                >
+                  <X size={16} />
+                </button>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* ToastContainer 실제 렌더링 */}
+      <GlobalToast />
     </div>
   )
 }

--- a/src/components/studyReport/RecordFileUpload.tsx
+++ b/src/components/studyReport/RecordFileUpload.tsx
@@ -27,7 +27,10 @@ export const RecordFileUpload = ({
   const [dragActive, setDragActive] = useState(false)
   const inputRef = useRef<HTMLInputElement | null>(null)
 
-  // 파일 선택 (클릭)
+  // 모바일 환경 감지
+  const isMobile = /iPhone|iPad|iPod|Android/i.test(navigator.userAgent)
+
+  // 파일 선택 (클릭/탭)
   const handleFileSelect = (e: ChangeEvent<HTMLInputElement>) => {
     const selected = e.target.files ? Array.from(e.target.files) : []
     const totalSize =
@@ -41,7 +44,7 @@ export const RecordFileUpload = ({
     toast.success(`${selected.length}개의 파일이 추가되었습니다.`)
   }
 
-  // 드래그 앤 드롭
+  // 드래그 앤 드롭 (데스크톱 전용)
   const handleDrop = (e: DragEvent<HTMLDivElement>) => {
     e.preventDefault()
     e.stopPropagation()
@@ -63,6 +66,7 @@ export const RecordFileUpload = ({
     toast.info(`파일 "${name}"이 삭제되었습니다.`)
   }
 
+  // 파일 아이콘 결정
   const getFileIcon = (file: File) => {
     const type = file.type
     const ext = file.name.split('.').pop()?.toLowerCase()
@@ -73,6 +77,8 @@ export const RecordFileUpload = ({
       return <Video className="text-gray-500" size={18} />
     if (type.startsWith('audio/'))
       return <Music className="text-gray-500" size={18} />
+    if (type.startsWith('text/') || type === 'application/json')
+      return <FileText className="text-gray-500" size={18} />
 
     switch (ext) {
       case 'pdf':
@@ -83,6 +89,9 @@ export const RecordFileUpload = ({
       case 'ppt':
       case 'pptx':
       case 'txt':
+      case 'csv':
+      case 'json':
+      case 'html':
         return <FileText className="text-gray-500" size={18} />
       default:
         return <FileIcon className="text-gray-500" size={18} />
@@ -100,15 +109,17 @@ export const RecordFileUpload = ({
             ? 'border-yellow-500 bg-yellow-50'
             : 'border-gray-200 bg-white'
         }`}
-        onDragOver={(e) => {
-          e.preventDefault()
-          setDragActive(true)
-        }}
-        onDragLeave={(e) => {
-          e.preventDefault()
-          setDragActive(false)
-        }}
-        onDrop={handleDrop}
+        {...(!isMobile && {
+          onDragOver: (e: DragEvent<HTMLDivElement>) => {
+            e.preventDefault()
+            setDragActive(true)
+          },
+          onDragLeave: (e: DragEvent<HTMLDivElement>) => {
+            e.preventDefault()
+            setDragActive(false)
+          },
+          onDrop: handleDrop,
+        })}
         onClick={() => inputRef.current?.click()}
       >
         <img
@@ -117,8 +128,19 @@ export const RecordFileUpload = ({
           className="mx-auto mb-3 h-10 w-10 opacity-70"
         />
         <p className="text-gray-500">
-          파일을 여기에 드래그하거나{' '}
-          <span className="font-semibold text-yellow-600">클릭하여 선택</span>
+          {isMobile ? (
+            <>
+              파일을{' '}
+              <span className="font-semibold text-yellow-600">탭하여 선택</span>
+            </>
+          ) : (
+            <>
+              파일을 여기에 드래그하거나{' '}
+              <span className="font-semibold text-yellow-600">
+                클릭하여 선택
+              </span>
+            </>
+          )}
         </p>
         <p className="mt-2 text-xs text-gray-400">
           모든 파일 형식 지원 (최대 10MB)
@@ -127,6 +149,8 @@ export const RecordFileUpload = ({
           ref={inputRef}
           type="file"
           multiple
+          accept="image/*,video/*,.pdf,.doc,.docx,.xls,.xlsx,.ppt,.pptx,.txt,.csv,.json,.html"
+          capture="environment"
           className="hidden"
           onChange={handleFileSelect}
         />

--- a/src/pages/study-groups/StudyRecord/StudyRecord.tsx
+++ b/src/pages/study-groups/StudyRecord/StudyRecord.tsx
@@ -68,6 +68,12 @@ export const StudyRecord = () => {
   }
 
   const handleSave = async () => {
+    // 내용이 없으면 토스트로 안내하고 저장 막기
+    if (title.trim() === '' || content.trim() === '') {
+      toast.warn('제목과 내용을 모두 입력해야 저장할 수 있습니다.')
+      return
+    }
+
     const recordData = { title, content, files }
     console.log('(MOCK) 저장 데이터:', recordData)
     await new Promise((resolve) => setTimeout(resolve, 300))
@@ -80,8 +86,6 @@ export const StudyRecord = () => {
 
     if (studyGroupId) navigate(`/study_group_detail/${studyGroupId}`)
   }
-
-  const isSaveDisabled = title.trim() === '' || content.trim() === ''
 
   return (
     <div className="flex min-h-screen w-[896px] flex-col items-center px-8 pt-[65px] pb-20">
@@ -109,7 +113,6 @@ export const StudyRecord = () => {
             onCancel={handleCancel}
             onSave={handleSave}
             mode={mode}
-            disabled={isSaveDisabled}
             studyGroupId={studyGroupId}
           />
         )}

--- a/src/pages/study-groups/StudyRecord/StudyRecord.tsx
+++ b/src/pages/study-groups/StudyRecord/StudyRecord.tsx
@@ -104,12 +104,15 @@ export const StudyRecord = () => {
       </div>
 
       <div className="mt-6 flex w-full max-w-3xl justify-between">
-        <RecordActionButtons
-          onCancel={handleCancel}
-          onSave={handleSave}
-          mode={mode}
-          disabled={isSaveDisabled}
-        />
+        {studyGroupId && (
+          <RecordActionButtons
+            onCancel={handleCancel}
+            onSave={handleSave}
+            mode={mode}
+            disabled={isSaveDisabled}
+            studyGroupId={studyGroupId}
+          />
+        )}
       </div>
     </div>
   )

--- a/src/pages/study-groups/StudyRecord/StudyRecord.tsx
+++ b/src/pages/study-groups/StudyRecord/StudyRecord.tsx
@@ -65,7 +65,6 @@ export const StudyRecord = () => {
     setContent('')
     setFiles([])
     toast.info('작성 중인 내용이 초기화되었습니다.')
-    toast.info('작성 중인 내용이 초기화되었습니다.')
   }
 
   const handleSave = async () => {
@@ -75,13 +74,10 @@ export const StudyRecord = () => {
 
     if (mode === 'edit') {
       toast.success('스터디 기록이 성공적으로 수정되었습니다.')
-      toast.success('스터디 기록이 성공적으로 수정되었습니다.')
     } else {
-      toast.success('새 스터디 기록이 성공적으로 저장되었습니다.')
       toast.success('새 스터디 기록이 성공적으로 저장되었습니다.')
     }
 
-    if (studyGroupId) navigate(`/study_group_detail/${studyGroupId}`)
     if (studyGroupId) navigate(`/study_group_detail/${studyGroupId}`)
   }
 

--- a/src/pages/study-groups/StudyRecord/StudyRecord.tsx
+++ b/src/pages/study-groups/StudyRecord/StudyRecord.tsx
@@ -1,47 +1,118 @@
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
+import { useParams, useNavigate } from 'react-router'
 import { RecordTitleInput } from '@/components/studyReport/RecordTitleInput'
 import { RecordMarkdownEditor } from '@/components/studyReport/RecordMarkdownEditor'
 import { RecordFileUpload } from '@/components/studyReport/RecordFileUpload'
 import { RecordActionButtons } from '@/components/studyReport/RecordActionButtons'
 import { RecordBreadcrumb } from '@/components/breadcrumb/RecordBreadcrumb'
+import { toast } from 'react-toastify'
+
+const MOCK_RECORD = {
+  title: '예시 스터디 기록 제목',
+  content: '여기에 학습 내용을 작성해보세요.',
+  files: [],
+}
 
 export const StudyRecord = () => {
   const [title, setTitle] = useState('')
   const [content, setContent] = useState('')
-  const [file, setFile] = useState<File | null>(null)
+  const [files, setFiles] = useState<File[]>([])
+  const [mode, setMode] = useState<'create' | 'edit'>('create')
+  const navigate = useNavigate()
+  const { studyGroupId, studyRecordId } = useParams<{
+    studyGroupId: string
+    studyRecordId: string
+  }>()
 
-  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const selectedFile = e.target.files?.[0] ?? null
-    setFile(selectedFile)
+  // 드래그 앤 드롭 방지
+  useEffect(() => {
+    const preventDefault = (e: DragEvent) => {
+      e.preventDefault()
+      e.stopPropagation()
+    }
+
+    window.addEventListener('dragover', preventDefault)
+    window.addEventListener('drop', preventDefault)
+
+    return () => {
+      window.removeEventListener('dragover', preventDefault)
+      window.removeEventListener('drop', preventDefault)
+    }
+  }, [])
+
+  // 기록 데이터 불러오기
+  const loadStudyRecord = async (groupId: string, recordId: string) => {
+    console.log(`(MOCK) 그룹 ${groupId} 기록 ${recordId} 불러오기`)
+    await new Promise((resolve) => setTimeout(resolve, 300))
+    setTitle(MOCK_RECORD.title)
+    setContent(MOCK_RECORD.content)
+    setFiles(MOCK_RECORD.files)
   }
+
+  useEffect(() => {
+    if (studyGroupId && studyRecordId) {
+      setMode('edit')
+      loadStudyRecord(studyGroupId, studyRecordId)
+    } else if (window.location.pathname.includes('edit')) {
+      setMode('edit')
+    }
+  }, [studyGroupId, studyRecordId])
+
+  const handleFilesChange = (newFiles: File[]) => setFiles(newFiles)
 
   const handleCancel = () => {
     setTitle('')
     setContent('')
-    setFile(null)
+    setFiles([])
+    toast.info('작성 중인 내용이 초기화되었습니다.')
+    toast.info('작성 중인 내용이 초기화되었습니다.')
   }
 
-  const handleSave = () => {}
+  const handleSave = async () => {
+    const recordData = { title, content, files }
+    console.log('(MOCK) 저장 데이터:', recordData)
+    await new Promise((resolve) => setTimeout(resolve, 300))
+
+    if (mode === 'edit') {
+      toast.success('스터디 기록이 성공적으로 수정되었습니다.')
+      toast.success('스터디 기록이 성공적으로 수정되었습니다.')
+    } else {
+      toast.success('새 스터디 기록이 성공적으로 저장되었습니다.')
+      toast.success('새 스터디 기록이 성공적으로 저장되었습니다.')
+    }
+
+    if (studyGroupId) navigate(`/study_group_detail/${studyGroupId}`)
+    if (studyGroupId) navigate(`/study_group_detail/${studyGroupId}`)
+  }
+
+  const isSaveDisabled = title.trim() === '' || content.trim() === ''
 
   return (
-    <div className="flex min-h-screen w-full flex-col items-center px-20 pt-[65px] pb-20">
+    <div className="flex min-h-screen w-[896px] flex-col items-center px-8 pt-[65px] pb-20">
       <div className="mb-6 w-full max-w-3xl">
-        <RecordBreadcrumb current="작성" />
-        <h1 className="mb-2 text-2xl font-bold">스터디 기록 작성</h1>
-        <p className="text-gray-600">학습한 내용을 자세히 기록해보세요</p>
+        <RecordBreadcrumb current={mode === 'edit' ? '수정' : '작성'} />
+        <h1 className="mb-2 text-2xl font-bold">
+          {mode === 'edit' ? '스터디 기록 수정' : '스터디 기록 작성'}
+        </h1>
+        <p className="text-gray-600">
+          {mode === 'edit'
+            ? '학습에서 작성된 내용을 수정하고 저장해보세요'
+            : '학습한 내용을 자세히 기록해보세요'}
+        </p>
       </div>
 
       <div className="w-full max-w-3xl rounded-2xl border border-gray-200 bg-white p-[25px]">
         <RecordTitleInput title={title} setTitle={setTitle} />
         <RecordMarkdownEditor content={content} setContent={setContent} />
-        <RecordFileUpload file={file} onFileChange={handleFileChange} />
+        <RecordFileUpload files={files} onFilesChange={handleFilesChange} />
       </div>
 
       <div className="mt-6 flex w-full max-w-3xl justify-between">
         <RecordActionButtons
           onCancel={handleCancel}
           onSave={handleSave}
-          mode="create"
+          mode={mode}
+          disabled={isSaveDisabled}
         />
       </div>
     </div>


### PR DESCRIPTION
## 📌 제목

- 스터디 기록 작성 기능구현

## 💡 개요

- 스터디의 기록을 작성하기 위한 api가 없는 기능구현을 완료

## 📝 상세 내용

<img width="1107" height="488" alt="스크린샷 2025-11-10 18 51 01" src="https://github.com/user-attachments/assets/897e542a-c8dd-45cf-85ff-fbd4a9fe80d9" />

- 클릭, 드래그 앤 드롭으로 파일을 업로드 할 수 있는 로직 구현

<img width="1128" height="572" alt="스크린샷 2025-11-10 18 52 57" src="https://github.com/user-attachments/assets/3f263d41-22be-4a75-bf7c-d4fb3884419e" />
<img width="1128" height="574" alt="스크린샷 2025-11-10 18 53 18" src="https://github.com/user-attachments/assets/0267202f-0d15-4740-bbce-ed186a24de6b" />

- 기록 수정 / 저장 페이지로 재활용 할 수 있도록 구현
- 저장된 내용을 불러와서 수정할 수 있는 로직 구현

<img width="1147" height="745" alt="스크린샷 2025-11-11 20 31 21" src="https://github.com/user-attachments/assets/e2ff2c7d-978d-439d-a292-99389dbd268e" />

- Toast 구현

## ✅ 체크리스트

- [ ] 코드에 불필요한 console.log 제거
- [ ] lint 검사 통과
- [ ] 테스트 통과
- [ ] 관련 문서/README 업데이트

## 🔗 관련 이슈

- close #이슈번호