### PR TITLE
fix: 스터디 그룹 페이지 검색 결과가 없을 때 컴포넌트 UI

### DIFF
--- a/src/components/searchStudy/NoStudiesResult.tsx
+++ b/src/components/searchStudy/NoStudiesResult.tsx
@@ -60,8 +60,7 @@ export const NoStudiesResult = ({
 
   // 출력 UI 내부에 컨텐츠( 이미지, 텍스트 등 )은 프롭스로 내려받아서 사용
   return (
-    <section className="min-h-screen w-full bg-gray-50 px-6 py-10">
-      <div className="mx-auto flex max-w-6xl flex-col items-center justify-center rounded-lg border border-gray-200 bg-white p-16">
+      <section className="mx-auto bg-gray-50 flex w-full flex-col items-center justify-center rounded-xl p-16">
         <div className="mb-6 rounded-full bg-gray-100 p-6">
           {currentStatus.icon}
         </div>
@@ -73,7 +72,6 @@ export const NoStudiesResult = ({
             <span>스터디 그룹 만들기</span>
           </BasicButton>
         )}
-      </div>
-    </section>
+      </section>
   )
 }

--- a/src/components/studyGroup/StudySection.tsx
+++ b/src/components/studyGroup/StudySection.tsx
@@ -21,6 +21,7 @@ export const StudySection = ({
 }: StudySectionProps) => {
   const [currentPage, setCurrentPage] = useState(0)
   const hasNoStudies = studies.length === 0
+  const subTitle = type === "active" ? "현재 활발히 진행되고 있는 스터디 그룹들" : "성공적으로 마무리된 스터디 그룹들"
 
   // 페이지네이션 계산
   const startIndex = currentPage * itemsPerPage
@@ -29,18 +30,17 @@ export const StudySection = ({
 
   return (
     <section className="mb-20 flex w-full flex-col">
-      <h2 className="mb-6 text-2xl font-semibold text-gray-800">{title}</h2>
+      <h2 className="pb-1 text-2xl font-semibold text-gray-800">{title}</h2>
+      <p className='text-gray-600'>{subTitle}</p>
 
       <div
-        className={`grid min-h-[60vh] w-full grid-cols-3 gap-6 ${
+        className={`grid pt-8 w-full grid-cols-3 gap-6 ${
           hasNoStudies ? 'place-items-center' : ''
         }`}
       >
         {hasNoStudies ? (
           <div className="col-span-full flex w-full justify-center">
-            <div className="w-full">
               <NoStudiesResult type={type} isSearchResult={isSearchResult} />
-            </div>
           </div>
         ) : (
           paginatedStudies.map((study) => (


### PR DESCRIPTION
    수정 (#124)

## 📌 제목

-fix: 스터디 그룹 페이지 검색 결과가 없을 때 컴포넌트 UI

## 💡 개요

- 피그마와 UI 일치 작업

## 📝 상세 내용

- 피그마와 UI 일치 작업
<img width="2019" height="1800" alt="UI수정본" src="https://github.com/user-attachments/assets/021ab4e0-6245-48e0-9799-12a9adb3baa2" />

## ✅ 체크리스트

- [ ] 코드에 불필요한 console.log 제거
- [ ] lint 검사 통과
- [ ] 테스트 통과
- [ ] 관련 문서/README 업데이트

## 🔗 관련 이슈

- close #124 이슈번호
