### PR TITLE
Feature/117 markdown tool2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "react-paginate": "^8.3.0",
         "react-router": "^7.6.2",
         "react-spinners": "^0.17.0",
+        "react-syntax-highlighter": "^16.1.0",
         "react-toastify": "^11.0.5",
         "remark-breaks": "^4.0.0",
         "remark-gfm": "^4.0.1",
@@ -271,6 +272,15 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.28.4",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.4.tgz",
+      "integrity": "sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/template": {
@@ -1690,6 +1700,12 @@
       "dependencies": {
         "undici-types": "~7.8.0"
       }
+    },
+    "node_modules/@types/prismjs": {
+      "version": "1.26.5",
+      "resolved": "https://registry.npmjs.org/@types/prismjs/-/prismjs-1.26.5.tgz",
+      "integrity": "sha512-AUZTa7hQ2KY5L7AmtSiqxlhWxb4ina0yd8hNbl4TWuqnv/pFP0nDMb3YrfSBf4hJVGLh2YEIBfKaBW/9UEl6IQ==",
+      "license": "MIT"
     },
     "node_modules/@types/react": {
       "version": "19.1.8",
@@ -3286,6 +3302,19 @@
         "reusify": "^1.0.4"
       }
     },
+    "node_modules/fault": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/fault/-/fault-1.0.4.tgz",
+      "integrity": "sha512-CJ0HCB5tL5fYTEA7ToAq5+kTwd++Borf1/bifxd9iT70QcXr4MRrO3Llf8Ifs70q+SJcGHFtnIE/Nw6giCtECA==",
+      "license": "MIT",
+      "dependencies": {
+        "format": "^0.2.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/file-entry-cache": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
@@ -3393,6 +3422,14 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/format": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/format/-/format-0.2.2.tgz",
+      "integrity": "sha512-wzsgA6WOq+09wrU1tsJ09udeR/YZRaeArL9e1wPbFg3GG2yDnC2ldKpxs4xunpFF9DgqCqOIra3bc1HWrJ37Ww==",
+      "engines": {
+        "node": ">=0.4.x"
       }
     },
     "node_modules/framer-motion": {
@@ -3679,6 +3716,19 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/hast-util-parse-selector": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-parse-selector/-/hast-util-parse-selector-4.0.0.tgz",
+      "integrity": "sha512-wkQCkSYoOGCRKERFWcxMVMOcYE2K1AaNLU8DXS9arxnLOUEWbOXKXiJUNzEpqZ3JOKpnha3jkFrumEjVliDe7A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/hast-util-to-jsx-runtime": {
       "version": "2.3.6",
       "resolved": "https://registry.npmjs.org/hast-util-to-jsx-runtime/-/hast-util-to-jsx-runtime-2.3.6.tgz",
@@ -3718,6 +3768,38 @@
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
       }
+    },
+    "node_modules/hastscript": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/hastscript/-/hastscript-9.0.1.tgz",
+      "integrity": "sha512-g7df9rMFX/SPi34tyGCyUBREQoKkapwdY/T04Qn9TDWfHhAYt4/I0gMVirzK5wEzeUqIjEB+LXC/ypb7Aqno5w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "hast-util-parse-selector": "^4.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/highlight.js": {
+      "version": "10.7.3",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.7.3.tgz",
+      "integrity": "sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/highlightjs-vue": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/highlightjs-vue/-/highlightjs-vue-1.0.0.tgz",
+      "integrity": "sha512-PDEfEF102G23vHmPhLyPboFCD+BkMGu+GuJe2d9/eH4FsCwvgBpnc9n0pGE+ffKdph38s6foEZiEjdgHdzp+IA==",
+      "license": "CC0-1.0"
     },
     "node_modules/html-url-attributes": {
       "version": "3.0.1",
@@ -4606,6 +4688,20 @@
       },
       "bin": {
         "loose-envify": "cli.js"
+      }
+    },
+    "node_modules/lowlight": {
+      "version": "1.20.0",
+      "resolved": "https://registry.npmjs.org/lowlight/-/lowlight-1.20.0.tgz",
+      "integrity": "sha512-8Ktj+prEb1RoCPkEOrPMYUN/nCggB7qAWe3a7OpMjWQkh3l2RD5wKRQ+o8Q8YuI9RG/xs95waaI/E6ym/7NsTw==",
+      "license": "MIT",
+      "dependencies": {
+        "fault": "^1.0.0",
+        "highlight.js": "~10.7.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/lru-cache": {
@@ -6037,6 +6133,15 @@
         }
       }
     },
+    "node_modules/prismjs": {
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.30.0.tgz",
+      "integrity": "sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/prop-types": {
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
@@ -6218,6 +6323,26 @@
         "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
+    "node_modules/react-syntax-highlighter": {
+      "version": "16.1.0",
+      "resolved": "https://registry.npmjs.org/react-syntax-highlighter/-/react-syntax-highlighter-16.1.0.tgz",
+      "integrity": "sha512-E40/hBiP5rCNwkeBN1vRP+xow1X0pndinO+z3h7HLsHyjztbyjfzNWNKuAsJj+7DLam9iT4AaaOZnueCU+Nplg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.28.4",
+        "highlight.js": "^10.4.1",
+        "highlightjs-vue": "^1.0.0",
+        "lowlight": "^1.17.0",
+        "prismjs": "^1.30.0",
+        "refractor": "^5.0.0"
+      },
+      "engines": {
+        "node": ">= 16.20.2"
+      },
+      "peerDependencies": {
+        "react": ">= 0.14.0"
+      }
+    },
     "node_modules/react-toastify": {
       "version": "11.0.5",
       "resolved": "https://registry.npmjs.org/react-toastify/-/react-toastify-11.0.5.tgz",
@@ -6251,6 +6376,22 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/refractor": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/refractor/-/refractor-5.0.0.tgz",
+      "integrity": "sha512-QXOrHQF5jOpjjLfiNk5GFnWhRXvxjUVnlFxkeDmewR5sXkr3iM46Zo+CnRR8B+MDVqkULW4EcLVcRBNOPXHosw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/prismjs": "^1.0.0",
+        "hastscript": "^9.0.0",
+        "parse-entities": "^4.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/regexp.prototype.flags": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,6 +37,7 @@
         "@types/node": "^24.0.3",
         "@types/react": "^19.1.2",
         "@types/react-dom": "^19.1.2",
+        "@types/react-syntax-highlighter": "^15.5.13",
         "@typescript-eslint/eslint-plugin": "^8.34.0",
         "@typescript-eslint/parser": "^8.34.0",
         "@vitejs/plugin-react": "^4.4.1",
@@ -1722,6 +1723,16 @@
       "dev": true,
       "peerDependencies": {
         "@types/react": "^19.0.0"
+      }
+    },
+    "node_modules/@types/react-syntax-highlighter": {
+      "version": "15.5.13",
+      "resolved": "https://registry.npmjs.org/@types/react-syntax-highlighter/-/react-syntax-highlighter-15.5.13.tgz",
+      "integrity": "sha512-uLGJ87j6Sz8UaBAooU0T6lWJ0dBmjZgN1PZTrj05TNql2/XpC6+4HhMT5syIdFUUt+FASfCeLLv4kBygNU+8qA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/react": "*"
       }
     },
     "node_modules/@types/unist": {

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "@types/node": "^24.0.3",
     "@types/react": "^19.1.2",
     "@types/react-dom": "^19.1.2",
+    "@types/react-syntax-highlighter": "^15.5.13",
     "@typescript-eslint/eslint-plugin": "^8.34.0",
     "@typescript-eslint/parser": "^8.34.0",
     "@vitejs/plugin-react": "^4.4.1",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "react-paginate": "^8.3.0",
     "react-router": "^7.6.2",
     "react-spinners": "^0.17.0",
+    "react-syntax-highlighter": "^16.1.0",
     "react-toastify": "^11.0.5",
     "remark-breaks": "^4.0.0",
     "remark-gfm": "^4.0.1",

--- a/src/components/breadcrumb/RecordBreadcrumb.tsx
+++ b/src/components/breadcrumb/RecordBreadcrumb.tsx
@@ -12,7 +12,7 @@ interface StudyParams {
   groupId?: string
 }
 
-const DEFAULT_HOME = '/'
+const DEFAULT_HOME = 'https://account.ozcoding.site/'
 const DEFAULT_GROUPS = '/'
 
 export const RecordBreadcrumb = ({
@@ -28,9 +28,15 @@ export const RecordBreadcrumb = ({
       aria-label="breadcrumb"
       className="mb-6 flex items-center gap-2 text-sm text-gray-500"
     >
-      <Link to={homeTo} className="hover:text-gray-700">
+      <a
+        href={homeTo}
+        className="hover:text-gray-700"
+        target="_self"
+        rel="noopener noreferrer"
+      >
         홈
-      </Link>
+      </a>
+
       <ChevronRight size={16} />
 
       <Link to={groupsTo} className="hover:text-gray-700">

--- a/src/components/breadcrumb/RecordBreadcrumb.tsx
+++ b/src/components/breadcrumb/RecordBreadcrumb.tsx
@@ -26,17 +26,17 @@ export const RecordBreadcrumb = ({
   return (
     <nav
       aria-label="breadcrumb"
-      className="mb-6 flex items-center text-sm text-gray-500"
+      className="mb-6 flex items-center gap-2 text-sm text-gray-500"
     >
       <Link to={homeTo} className="hover:text-gray-700">
         홈
       </Link>
-      <ChevronRight size={16} className="mx-1" />
+      <ChevronRight size={16} />
 
       <Link to={groupsTo} className="hover:text-gray-700">
         스터디 그룹
       </Link>
-      <ChevronRight size={16} className="mx-1" />
+      <ChevronRight size={16} />
 
       <Link
         to={`/study_group/${resolvedGroupId}`}
@@ -44,7 +44,7 @@ export const RecordBreadcrumb = ({
       >
         스터디 상세
       </Link>
-      <ChevronRight size={16} className="mx-1" />
+      <ChevronRight size={16} />
 
       <span className="font-medium text-gray-800">기록 {current}</span>
     </nav>

--- a/src/components/markdown/MarkdownGuide.tsx
+++ b/src/components/markdown/MarkdownGuide.tsx
@@ -1,0 +1,16 @@
+export const MarkdownGuide = () => {
+  return (
+    <div className="border-t border-gray-200 bg-[#F9FAFB] px-4 py-2">
+      <p className="text-[12px] leading-[16px] font-normal text-[#4B5563]">
+        마크다운 문법을 사용할 수 있습니다.
+        <span className="ml-2 inline-flex items-center gap-[8px] font-medium text-[#4B5563]">
+          <span>**굵게**</span>
+          <span>_기울임_</span>
+          <span>`코드`</span>
+          <span>[링크](URL)</span>
+          <span>## 제목</span>
+        </span>
+      </p>
+    </div>
+  )
+}

--- a/src/components/markdown/MarkdownToolbar.tsx
+++ b/src/components/markdown/MarkdownToolbar.tsx
@@ -30,20 +30,24 @@ export const MarkdownToolbar = ({
 }: MarkdownToolbarProps) => {
   const fileInputRef = useRef<HTMLInputElement | null>(null)
 
+  const getLineRange = (value: string, caret: number) => {
+    const start = value.lastIndexOf('\n', Math.max(0, caret - 1)) + 1
+    const nextNewline = value.indexOf('\n', caret)
+    const end = nextNewline === -1 ? value.length : nextNewline
+    return [start, end] as const
+  }
+
   const toggleWrap = (wrapper: string) => {
     const ta = textareaRef.current
     if (!ta) return
     const { selectionStart: ss, selectionEnd: se, value } = ta
     const selected = value.slice(ss, se)
-
     const isWrapped = selected.startsWith(wrapper) && selected.endsWith(wrapper)
     const newSelected = isWrapped
       ? selected.slice(wrapper.length, selected.length - wrapper.length)
       : `${wrapper}${selected}${wrapper}`
-
     const newValue = value.slice(0, ss) + newSelected + value.slice(se)
     onUpdate(newValue)
-
     requestAnimationFrame(() => {
       ta.focus()
       ta.selectionStart = ss
@@ -54,11 +58,13 @@ export const MarkdownToolbar = ({
   const toggleHeading = () => {
     const ta = textareaRef.current
     if (!ta) return
-    const { selectionStart: ss, selectionEnd: se, value } = ta
+    const { value } = ta
+    let ss = ta.selectionStart
+    let se = ta.selectionEnd
+    if (ss === se) [ss, se] = getLineRange(value, ss)
     const selected = value.slice(ss, se)
     const lines = selected.split('\n')
     const allHaveHeading = lines.every((line) => /^##\s/.test(line))
-
     const newLines = lines.map((line) =>
       !line.trim()
         ? line
@@ -66,11 +72,9 @@ export const MarkdownToolbar = ({
           ? line.replace(/^##\s?/, '')
           : `## ${line.replace(/^##\s?/, '')}`
     )
-
     const newSelected = newLines.join('\n')
     const newValue = value.slice(0, ss) + newSelected + value.slice(se)
     onUpdate(newValue)
-
     requestAnimationFrame(() => {
       ta.focus()
       ta.selectionStart = ss
@@ -81,11 +85,13 @@ export const MarkdownToolbar = ({
   const toggleList = () => {
     const ta = textareaRef.current
     if (!ta) return
-    const { selectionStart: ss, selectionEnd: se, value } = ta
+    const { value } = ta
+    let ss = ta.selectionStart
+    let se = ta.selectionEnd
+    if (ss === se) [ss, se] = getLineRange(value, ss)
     const selected = value.slice(ss, se)
     const lines = selected.split('\n')
     const allHaveList = lines.every((line) => /^-\s/.test(line))
-
     const newLines = lines.map((line) =>
       !line.trim()
         ? line
@@ -93,11 +99,9 @@ export const MarkdownToolbar = ({
           ? line.replace(/^-\s?/, '')
           : `- ${line.replace(/^-\s?/, '')}`
     )
-
     const newSelected = newLines.join('\n')
     const newValue = value.slice(0, ss) + newSelected + value.slice(se)
     onUpdate(newValue)
-
     requestAnimationFrame(() => {
       ta.focus()
       ta.selectionStart = ss
@@ -109,19 +113,13 @@ export const MarkdownToolbar = ({
     const ta = textareaRef.current
     if (!ta) return
     const { selectionStart: ss, selectionEnd: se, value } = ta
-    const selected = value.slice(ss, se)
-
-    const isBlock = /^```[\s\S]*```$/.test(selected.trim())
-
+    const selected = value.slice(ss, se).trim()
+    const isBlock = /^```[\s\S]*```$/.test(selected)
     const newSelected = isBlock
-      ? selected.replace(/^```[\s\S]*```$/, (m) =>
-          m.replace(/^```|```$/g, '').trim()
-        )
-      : `\`\`\`\n${selected.trim() || ''}\n\`\`\``
-
+      ? selected.replace(/^```|```$/g, '').trim()
+      : `\`\`\`\n${selected}\n\`\`\``
     const newValue = value.slice(0, ss) + newSelected + value.slice(se)
     onUpdate(newValue)
-
     requestAnimationFrame(() => {
       ta.focus()
       ta.selectionStart = ss
@@ -132,19 +130,38 @@ export const MarkdownToolbar = ({
   const toggleLink = () => {
     const ta = textareaRef.current
     if (!ta) return
-    const { selectionStart: ss, selectionEnd: se, value } = ta
-    const selected = value.slice(ss, se)
+    const { value } = ta
+    let ss = ta.selectionStart
+    let se = ta.selectionEnd
+    let selected = value.slice(ss, se)
+    const linkRegex = /\[[^\]]+\]\((?:https?:\/\/)?[^\s)]+\)/
 
-    const linkPattern = /^\[.*?\]\(.*?\)$/
-    const newValue = linkPattern.test(selected)
-      ? value.slice(0, ss) +
-        selected.replace(/^\[(.*?)\]\(.*?\)$/, '$1') +
-        value.slice(se)
-      : value.slice(0, ss) +
-        `[${selected || '링크텍스트'}](https://)` +
-        value.slice(se)
+    if (ss === se) {
+      const [ls, le] = getLineRange(value, ss)
+      const line = value.slice(ls, le)
+      const match = [...line.matchAll(linkRegex)].find((m) => {
+        const start = ls + (m.index ?? 0)
+        const end = start + m[0].length
+        return start <= ss && ss <= end
+      })
+      if (match) {
+        ss = ls + (match.index ?? 0)
+        se = ss + match[0].length
+        selected = match[0]
+      }
+    }
 
+    const isLink = linkRegex.test(selected)
+    const newSelected = isLink
+      ? selected.replace(/^\[([^\]]+)\]\([^)]*\)$/, '$1')
+      : `[${selected || '링크텍스트'}](https://)`
+    const newValue = value.slice(0, ss) + newSelected + value.slice(se)
     onUpdate(newValue)
+    requestAnimationFrame(() => {
+      ta.focus()
+      ta.selectionStart = ss
+      ta.selectionEnd = ss + newSelected.length
+    })
   }
 
   const handleFileSelect = (e: React.ChangeEvent<HTMLInputElement>) => {

--- a/src/components/markdown/MarkdownToolbar.tsx
+++ b/src/components/markdown/MarkdownToolbar.tsx
@@ -18,6 +18,7 @@ import {
   MAX_IMAGE_SIZE_BYTES,
   UPLOAD_ERROR_MESSAGES,
 } from '@/constants/upload'
+import { toast } from 'react-toastify'
 
 export interface MarkdownToolbarProps {
   textareaRef: RefObject<HTMLTextAreaElement | null>
@@ -168,16 +169,17 @@ export const MarkdownToolbar = ({
     const file = e.target.files?.[0]
     if (!file) return
     if (!ALLOWED_IMAGE_TYPES.includes(file.type)) {
-      alert(UPLOAD_ERROR_MESSAGES.invalidType)
+      toast.error(UPLOAD_ERROR_MESSAGES.invalidType)
       return
     }
     if (file.size > MAX_IMAGE_SIZE_BYTES) {
-      alert(UPLOAD_ERROR_MESSAGES.tooLarge)
+      toast.error(UPLOAD_ERROR_MESSAGES.tooLarge)
       return
     }
     const imageURL = URL.createObjectURL(file)
     const markdownImage = `![${file.name}](${imageURL})`
     onUpdate((prev) => prev + '\n' + markdownImage)
+    toast.success('이미지가 추가되었습니다.')
   }
 
   return (

--- a/src/components/markdown/MarkdownToolbar.tsx
+++ b/src/components/markdown/MarkdownToolbar.tsx
@@ -37,7 +37,6 @@ export const MarkdownToolbar = ({
     const selected = value.slice(ss, se)
 
     const isWrapped = selected.startsWith(wrapper) && selected.endsWith(wrapper)
-
     const newSelected = isWrapped
       ? selected.slice(wrapper.length, selected.length - wrapper.length)
       : `${wrapper}${selected}${wrapper}`
@@ -106,7 +105,29 @@ export const MarkdownToolbar = ({
     })
   }
 
-  const toggleCode = () => toggleWrap('`')
+  const toggleCodeBlock = () => {
+    const ta = textareaRef.current
+    if (!ta) return
+    const { selectionStart: ss, selectionEnd: se, value } = ta
+    const selected = value.slice(ss, se)
+
+    const isBlock = /^```[\s\S]*```$/.test(selected.trim())
+
+    const newSelected = isBlock
+      ? selected.replace(/^```[\s\S]*```$/, (m) =>
+          m.replace(/^```|```$/g, '').trim()
+        )
+      : `\`\`\`\n${selected.trim() || ''}\n\`\`\``
+
+    const newValue = value.slice(0, ss) + newSelected + value.slice(se)
+    onUpdate(newValue)
+
+    requestAnimationFrame(() => {
+      ta.focus()
+      ta.selectionStart = ss
+      ta.selectionEnd = ss + newSelected.length
+    })
+  }
 
   const toggleLink = () => {
     const ta = textareaRef.current
@@ -157,7 +178,7 @@ export const MarkdownToolbar = ({
       <Code2
         size={18}
         className="cursor-pointer hover:text-amber-500"
-        onClick={toggleCode}
+        onClick={toggleCodeBlock}
       />
       <div className="relative">
         <FileImage

--- a/src/components/markdown/MarkdownWrite.tsx
+++ b/src/components/markdown/MarkdownWrite.tsx
@@ -77,7 +77,6 @@ export const MarkdownWrite = ({
                   <ul className="list-disc pl-6 text-gray-700">{children}</ul>
                 ),
                 li: ({ children }) => <li className="ml-2">{children}</li>,
-
                 code({
                   inline,
                   className,
@@ -150,10 +149,14 @@ export const MarkdownWrite = ({
       )}
 
       <div className="border-t border-gray-200 bg-[#F9FAFB] px-4 py-2 text-xs text-gray-600">
-        마크다운 문법을 사용할 수 있습니다.{' '}
-        <span className="font-medium text-gray-600">
-          **굵게** _기울임_ `코드` [링크](URL) ## 제목
-        </span>
+        마크다운 문법을 사용할 수 있습니다.
+        <div className="mt-1 flex flex-wrap items-center gap-2 font-medium text-gray-600">
+          <span>**굵게**</span>
+          <span>_기울임_</span>
+          <span>`코드`</span>
+          <span>[링크](URL)</span>
+          <span>## 제목</span>
+        </div>
       </div>
     </div>
   )

--- a/src/components/markdown/MarkdownWrite.tsx
+++ b/src/components/markdown/MarkdownWrite.tsx
@@ -10,6 +10,7 @@ import remarkBreaks from 'remark-breaks'
 import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter'
 import { oneDark } from 'react-syntax-highlighter/dist/esm/styles/prism'
 import { MarkdownToolbar } from './MarkdownToolbar'
+import { MarkdownGuide } from './MarkdownGuide'
 
 interface MarkdownWriteProps {
   value: string
@@ -67,6 +68,40 @@ export const MarkdownWrite = ({
             <ReactMarkdown
               remarkPlugins={[remarkBreaks]}
               components={{
+                a: ({ node, ...props }) => {
+                  let href = props.href?.trim() || ''
+                  const linkText = String(props.children).trim()
+
+                  if (
+                    (!href || href === 'https://' || href === 'http://') &&
+                    /^(https?:\/\/|www\.)[^\s]+$/.test(linkText)
+                  ) {
+                    href = linkText
+                  }
+
+                  if (!/^https?:\/\//.test(href)) {
+                    href = `https://${href.replace(/^\/+/, '')}`
+                  }
+
+                  const handleClick = (
+                    e: React.MouseEvent<HTMLAnchorElement>
+                  ) => {
+                    e.preventDefault()
+                    window.open(href, '_blank', 'noopener,noreferrer')
+                  }
+
+                  return (
+                    <a
+                      {...props}
+                      href={href}
+                      onClick={handleClick}
+                      className="text-amber-600 hover:underline"
+                    >
+                      {props.children}
+                    </a>
+                  )
+                },
+
                 h2: ({ node: _, ...props }) => (
                   <h2
                     {...props}
@@ -148,16 +183,7 @@ export const MarkdownWrite = ({
         </div>
       )}
 
-      <div className="border-t border-gray-200 bg-[#F9FAFB] px-4 py-2 text-xs text-gray-600">
-        마크다운 문법을 사용할 수 있습니다.
-        <div className="mt-1 flex flex-wrap items-center gap-2 font-medium text-gray-600">
-          <span>**굵게**</span>
-          <span>_기울임_</span>
-          <span>`코드`</span>
-          <span>[링크](URL)</span>
-          <span>## 제목</span>
-        </div>
-      </div>
+      <MarkdownGuide />
     </div>
   )
 }

--- a/src/components/markdown/MarkdownWrite.tsx
+++ b/src/components/markdown/MarkdownWrite.tsx
@@ -6,7 +6,6 @@ import {
   type SetStateAction,
 } from 'react'
 import ReactMarkdown from 'react-markdown'
-import remarkBreaks from 'remark-breaks'
 import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter'
 import { oneDark } from 'react-syntax-highlighter/dist/esm/styles/prism'
 import { MarkdownToolbar } from './MarkdownToolbar'
@@ -66,7 +65,7 @@ export const MarkdownWrite = ({
         <div className="min-h-[180px] bg-white p-4 text-sm text-gray-700">
           {previewValue.trim() ? (
             <ReactMarkdown
-              remarkPlugins={[remarkBreaks]}
+              remarkPlugins={[]}
               components={{
                 a: ({ node, ...props }) => {
                   let href = props.href?.trim() || ''

--- a/src/components/markdown/MarkdownWrite.tsx
+++ b/src/components/markdown/MarkdownWrite.tsx
@@ -7,6 +7,8 @@ import {
 } from 'react'
 import ReactMarkdown from 'react-markdown'
 import remarkBreaks from 'remark-breaks'
+import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter'
+import { oneDark } from 'react-syntax-highlighter/dist/esm/styles/prism'
 import { MarkdownToolbar } from './MarkdownToolbar'
 
 interface MarkdownWriteProps {
@@ -75,6 +77,68 @@ export const MarkdownWrite = ({
                   <ul className="list-disc pl-6 text-gray-700">{children}</ul>
                 ),
                 li: ({ children }) => <li className="ml-2">{children}</li>,
+
+                code({
+                  inline,
+                  className,
+                  children,
+                  ...props
+                }: {
+                  inline?: boolean
+                  className?: string
+                  children?: React.ReactNode
+                  [key: string]: any
+                }) {
+                  const match = /language-(\w+)/.exec(className || '')
+                  let language = match ? match[1] : undefined
+                  const codeText = String(children).trim()
+
+                  if (!language) {
+                    if (/\b(type|interface|=>|<.*?>)\b/.test(codeText))
+                      language = 'typescript'
+                    else if (
+                      /\b(const|let|var|function|return|console\.log)\b/.test(
+                        codeText
+                      )
+                    )
+                      language = 'javascript'
+                    else if (/{|}/.test(codeText)) language = 'json'
+                    else language = 'plaintext'
+                  }
+
+                  if (inline) {
+                    return (
+                      <code
+                        {...props}
+                        className="rounded bg-gray-100 px-1.5 py-0.5 text-[13px] text-gray-800"
+                      >
+                        {children}
+                      </code>
+                    )
+                  }
+
+                  return (
+                    <div className="relative my-3">
+                      <div className="absolute top-2 left-2 rounded-full bg-[#1b1f2a] px-3 py-0.5 text-[11px] font-medium text-gray-400">
+                        {language}
+                      </div>
+                      <SyntaxHighlighter
+                        {...props}
+                        language={language}
+                        style={oneDark}
+                        PreTag="div"
+                        customStyle={{
+                          borderRadius: '10px',
+                          padding: '36px 16px 14px 16px',
+                          fontSize: '13px',
+                          backgroundColor: '#0f172a',
+                        }}
+                      >
+                        {codeText.replace(/\n$/, '')}
+                      </SyntaxHighlighter>
+                    </div>
+                  )
+                },
               }}
             >
               {previewValue}
@@ -86,7 +150,7 @@ export const MarkdownWrite = ({
       )}
 
       <div className="border-t border-gray-200 bg-[#F9FAFB] px-4 py-2 text-xs text-gray-600">
-        마크다운 문법을 사용할 수 있습니다.{` `}
+        마크다운 문법을 사용할 수 있습니다.{' '}
         <span className="font-medium text-gray-600">
           **굵게** _기울임_ `코드` [링크](URL) ## 제목
         </span>

--- a/src/components/upload/ImageUploadBox.tsx
+++ b/src/components/upload/ImageUploadBox.tsx
@@ -1,5 +1,6 @@
 import { useRef } from 'react'
 import { X } from 'lucide-react'
+import { toast } from 'react-toastify'
 import ImageUploadIcon from '/icons/image-upload-icon.svg'
 
 interface ImageUploadBoxProps {
@@ -16,16 +17,18 @@ export const ImageUploadBox = ({
   const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0] || null
     if (file && file.size > 5 * 1024 * 1024) {
-      alert('5MB 이하의 이미지만 업로드 가능합니다.')
+      toast.warn('5MB 이하의 이미지만 업로드 가능합니다.')
       return
     }
     onFileSelect(file)
+    if (file) toast.success('이미지가 업로드되었습니다.')
   }
 
   const handleClearFile = (e: React.MouseEvent) => {
     e.stopPropagation()
     onFileSelect(null)
     if (fileInputRef.current) fileInputRef.current.value = ''
+    toast.info('이미지가 삭제되었습니다.')
   }
 
   return (

--- a/src/pages/study-groups/CreateStudyGroup.tsx
+++ b/src/pages/study-groups/CreateStudyGroup.tsx
@@ -9,6 +9,7 @@ import { BasicButton } from '@/components/basicComponents/BasicButton/BasicButto
 import dayjs from '@/lib/dayjs'
 import { useNavigate } from 'react-router'
 import { storeDatePicker } from '@/store/storeDatePicker'
+import { toast } from 'react-toastify'
 
 export const CreateStudyGroup = () => {
   const [form, setForm] = useState<StudyGroupForm>({
@@ -41,15 +42,12 @@ export const CreateStudyGroup = () => {
 
   const handleSubmit = () => {
     if (!form.name || !form.startDate) {
-      alert('필수 항목을 모두 입력해주세요.')
+      toast.warn('필수 항목을 모두 입력해주세요.')
       return
     }
 
-    if (isEdit) {
-      alert('스터디 그룹이 수정되었습니다.')
-    } else {
-      alert('스터디 그룹이 생성되었습니다.')
-    }
+    if (isEdit) toast.success('스터디 그룹이 수정되었습니다.')
+    else toast.success('스터디 그룹이 생성되었습니다.')
 
     setForm({
       ...form,

--- a/src/pages/study-groups/CreateStudyGroup.tsx
+++ b/src/pages/study-groups/CreateStudyGroup.tsx
@@ -10,6 +10,7 @@ import dayjs from '@/lib/dayjs'
 import { useNavigate } from 'react-router'
 import { storeDatePicker } from '@/store/storeDatePicker'
 import { toast } from 'react-toastify'
+import { useModal } from '@/hooks/useModal'
 
 export const CreateStudyGroup = () => {
   const [form, setForm] = useState<StudyGroupForm>({
@@ -25,6 +26,7 @@ export const CreateStudyGroup = () => {
   const [isEdit, setIsEdit] = useState(false)
   const { startDate, endDate, reset } = storeDatePicker()
   const navigate = useNavigate()
+  const { openConfirm } = useModal()
 
   useEffect(() => {
     if (window.location.pathname.includes('edit')) {
@@ -58,8 +60,15 @@ export const CreateStudyGroup = () => {
   }
 
   const handleBack = () => {
-    reset()
-    navigate('/')
+    openConfirm({
+      message: '정말 취소하시겠어요?',
+      onConfirm: async () => {
+        reset()
+        navigate('/')
+      },
+      confirmText: '확인',
+      cancelText: '취소',
+    })
   }
 
   return (

--- a/src/pages/study-records/StudyRecordDetail.tsx
+++ b/src/pages/study-records/StudyRecordDetail.tsx
@@ -12,7 +12,9 @@ export const StudyRecordDetail = () => {
   const { data } = dummyStudyRecordDetail
   const { title, author, content, ai_summary, attachments, created_at } = data
 
-  const handleBack = () => alert('스터디 그룹으로 돌아가기')
+  const handleBack = () => {
+    // TODO: 추후 navigate('/study-groups/ID') 등으로 연결 예정
+  }
 
   return (
     <div className="mx-auto max-w-5xl px-6 py-10">

--- a/src/pages/study-records/sections/StudyRecordHeader.tsx
+++ b/src/pages/study-records/sections/StudyRecordHeader.tsx
@@ -19,6 +19,14 @@ export const StudyRecordHeader = ({
 }: StudyRecordHeaderProps) => {
   const [isImageError, setIsImageError] = useState(false)
 
+  const handleEdit = () => {
+    // TODO: 수정 페이지 이동
+  }
+
+  const handleDelete = () => {
+    // TODO: 삭제 확인 모달
+  }
+
   return (
     <>
       <div className="mb-4 flex items-start justify-between">
@@ -29,7 +37,7 @@ export const StudyRecordHeader = ({
             variant="secondary"
             size="small"
             className="!h-[32px] !rounded-lg !bg-[#F3F4F6] !px-3 !py-[6px] !text-[14px] !font-medium !text-[#374151]"
-            onClick={() => alert('수정하기')}
+            onClick={handleEdit}
           >
             수정하기
           </BasicButton>
@@ -38,7 +46,7 @@ export const StudyRecordHeader = ({
             variant="danger"
             size="small"
             className="!h-[32px] !rounded-lg !bg-[#FEE2E2] !px-3 !py-[6px] !text-[14px] !font-medium !text-[#B91C1C] hover:!bg-[#FEE2E2] active:!bg-[#FEE2E2]"
-            onClick={() => alert('삭제하기')}
+            onClick={handleDelete}
           >
             삭제하기
           </BasicButton>

--- a/src/test/TestE.tsx
+++ b/src/test/TestE.tsx
@@ -1,4 +1,6 @@
 import { CreateStudyGroup } from '@/pages/study-groups/CreateStudyGroup'
+import { ToastContainer } from 'react-toastify'
+import 'react-toastify/dist/ReactToastify.css'
 
 export default function TestE() {
   // 아래줄 주석처리 후 링크 TestE 변경-생성 모드, 주석해제 후 링크 TestE 변경-수정 모드
@@ -28,6 +30,18 @@ export default function TestE() {
       <div className="min-h-screen bg-gray-50 pt-[65px]">
         <CreateStudyGroup />
       </div>
+
+      <ToastContainer
+        position="top-right"
+        autoClose={2000}
+        hideProgressBar={false}
+        newestOnTop={false}
+        closeOnClick
+        pauseOnFocusLoss={false}
+        draggable
+        pauseOnHover
+        theme="light"
+      />
     </>
   )
 }

--- a/src/test/TestE.tsx
+++ b/src/test/TestE.tsx
@@ -1,5 +1,7 @@
 import { CreateStudyGroup } from '@/pages/study-groups/CreateStudyGroup'
 import { ToastContainer } from 'react-toastify'
+import { BasicModal } from '@/components/basicComponents/basicModal/BasicModal'
+import { createPortal } from 'react-dom'
 import 'react-toastify/dist/ReactToastify.css'
 
 export default function TestE() {
@@ -30,6 +32,9 @@ export default function TestE() {
       <div className="min-h-screen bg-gray-50 pt-[65px]">
         <CreateStudyGroup />
       </div>
+
+      {typeof document !== 'undefined' &&
+        createPortal(<BasicModal />, document.body)}
 
       <ToastContainer
         position="top-right"

--- a/src/test/TestE.tsx
+++ b/src/test/TestE.tsx
@@ -1,8 +1,7 @@
 import { CreateStudyGroup } from '@/pages/study-groups/CreateStudyGroup'
-import { ToastContainer } from 'react-toastify'
 import { BasicModal } from '@/components/basicComponents/basicModal/BasicModal'
 import { createPortal } from 'react-dom'
-import 'react-toastify/dist/ReactToastify.css'
+import { GlobalToast } from '@/components/basicComponents/toast/ToastContainer'
 
 export default function TestE() {
   // 아래줄 주석처리 후 링크 TestE 변경-생성 모드, 주석해제 후 링크 TestE 변경-수정 모드
@@ -36,17 +35,7 @@ export default function TestE() {
       {typeof document !== 'undefined' &&
         createPortal(<BasicModal />, document.body)}
 
-      <ToastContainer
-        position="top-right"
-        autoClose={2000}
-        hideProgressBar={false}
-        newestOnTop={false}
-        closeOnClick
-        pauseOnFocusLoss={false}
-        draggable
-        pauseOnHover
-        theme="light"
-      />
+      <GlobalToast />
     </>
   )
 }

--- a/src/types/react-syntax-highlighter.d.ts
+++ b/src/types/react-syntax-highlighter.d.ts
@@ -1,0 +1,2 @@
+declare module 'react-syntax-highlighter'
+declare module 'react-syntax-highlighter/dist/esm/styles/prism'


### PR DESCRIPTION
## 📌 제목

-Feature/117 markdown tool2

## 💡 개요

-[마크다운] 툴 기능 개선-2차

## 📝 상세 내용

-코드, 링크 기능 구현
![코드기능](https://github.com/user-attachments/assets/9bbeb73d-4112-4cfd-876e-5306cc9dfcc1)
![링크구현](https://github.com/user-attachments/assets/a68c0c4a-95f4-4f89-af3f-e68cbeba767f)

-하단문구, Breadcrumb 간격 수정

-alert 제거 및 toast 구현

-취소 모달 구현 및 경로 이동
<img width="747" height="946" alt="스크린샷 2025-11-12 16 16 55" src="https://github.com/user-attachments/assets/ca63a16e-dd42-411a-baaa-06174c43acba" />

[추후작업]
이미지 = presignedUrl

## ✅ 체크리스트

- [ ] 코드에 불필요한 console.log 제거
- [ ] lint 검사 통과
- [ ] 테스트 통과
- [ ] 관련 문서/README 업데이트

## 🔗 관련 이슈

- close #117 
