### PR TITLE
fix:모달 위에서 토스트 뜨도록 수정

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,8 +10,8 @@ export const App = () => {
   return (
     <QueryClientProvider client={queryClient}>
       <NavbarLayout />
-      <GlobalToast />
       <BasicModal />
+      <GlobalToast />
     </QueryClientProvider>
   )
 }

--- a/src/components/basicComponents/basicModal/BasicModal.tsx
+++ b/src/components/basicComponents/basicModal/BasicModal.tsx
@@ -1,5 +1,5 @@
 import { createPortal } from 'react-dom'
-import { motion } from 'framer-motion'
+import { AnimatePresence, motion } from 'framer-motion'
 import { useEffect, useRef } from 'react'
 import { storeModalOpen } from '@/store/storeModalOpen'
 import { ModalHeader } from '@/components/modal/ModalHeader'
@@ -88,33 +88,35 @@ export const BasicModal = () => {
   }
 
   return createPortal(
-    isModalOpen && (
-      <motion.div
-        className="fixed inset-0 z-[9999] flex items-center justify-center bg-black/50 p-4 backdrop-blur-sm"
-        variants={modalAnim}
-        initial="hidden"
-        animate="visible"
-        transition={{ duration: 0.1 }}
-        role="dialog"
-        aria-modal="true"
-        onClick={closeModal}
-      >
+    <AnimatePresence>
+      {isModalOpen && (
         <motion.div
-          className="relative flex h-auto max-h-[90vh] flex-col items-center justify-center rounded-xl bg-white shadow-2xl"
-          variants={contentAnim}
-          ref={modalRef}
+          className="fixed inset-0 z-[9999] flex items-center justify-center bg-black/50 p-4 backdrop-blur-sm"
+          variants={modalAnim}
           initial="hidden"
           animate="visible"
-          transition={{ type: 'spring', stiffness: 280, damping: 25 }}
-          onClick={(e) => e.stopPropagation()}
+          transition={{ duration: 0.1 }}
+          role="dialog"
+          aria-modal="true"
+          onClick={closeModal}
         >
-          <div className="transparent-scrollbar">
-            <ModalHeader />
-            {renderModalContent()}
-          </div>
+          <motion.div
+            className="relative flex h-auto max-h-[90vh] flex-col items-center justify-center rounded-xl bg-white shadow-2xl"
+            variants={contentAnim}
+            ref={modalRef}
+            initial="hidden"
+            animate="visible"
+            transition={{ type: 'spring', stiffness: 280, damping: 25 }}
+            onClick={(e) => e.stopPropagation()}
+          >
+            <div className="transparent-scrollbar">
+              <ModalHeader />
+              {renderModalContent()}
+            </div>
+          </motion.div>
         </motion.div>
-      </motion.div>
-    ),
+      )}
+    </AnimatePresence>,
     document.body
   )
 }

--- a/src/components/basicComponents/toast/ToastContainer.tsx
+++ b/src/components/basicComponents/toast/ToastContainer.tsx
@@ -1,16 +1,21 @@
+import { createPortal } from 'react-dom'
 import { ToastContainer } from 'react-toastify'
 import 'react-toastify/dist/ReactToastify.css'
 
-export const GlobalToast = () => (
-  <ToastContainer
-    position="top-right"
-    autoClose={2000}
-    hideProgressBar={false}
-    newestOnTop={false}
-    closeOnClick
-    pauseOnFocusLoss={false}
-    draggable
-    pauseOnHover
-    theme="light"
-  />
-)
+export const GlobalToast = () => {
+  return createPortal(
+    <ToastContainer
+      style={{ zIndex: 10000 }}
+      position="top-right"
+      autoClose={2000}
+      hideProgressBar={false}
+      newestOnTop={false}
+      closeOnClick
+      pauseOnFocusLoss={false}
+      draggable
+      pauseOnHover
+      theme="light"
+    />,
+    document.body
+  )
+}

--- a/src/components/modal/reviewDetail/ReviewDetailModal.tsx
+++ b/src/components/modal/reviewDetail/ReviewDetailModal.tsx
@@ -11,7 +11,6 @@ import { storeModalOpen } from '@/store/storeModalOpen'
 import type { ModalPropsMap } from '@/types/Modal'
 import { toast } from 'react-toastify'
 import { ReviewDetailSkeleton } from './ReviewDetailSkeleton'
-import { GlobalToast } from '@/components/basicComponents/toast/ToastContainer'
 
 const ORDERING: Ordering = '-updated_at'
 const PAGE_SIZE = 10
@@ -96,8 +95,6 @@ export const ReviewDetailModal = () => {
           </span>
         )}
       </footer>
-
-      <GlobalToast />
     </div>
   )
 }

--- a/src/components/studyReport/RecordFileUpload.tsx
+++ b/src/components/studyReport/RecordFileUpload.tsx
@@ -1,5 +1,4 @@
-import { useState, useRef } from 'react'
-import type { DragEvent, ChangeEvent } from 'react'
+import { useState, useRef, type ChangeEvent, type DragEvent } from 'react'
 import {
   FileText,
   Image,
@@ -10,7 +9,6 @@ import {
   Paperclip,
 } from 'lucide-react'
 import 'react-toastify/dist/ReactToastify.css'
-import { GlobalToast } from '@/components/basicComponents/toast/ToastContainer'
 import { toast } from 'react-toastify'
 
 interface RecordFileUploadProps {
@@ -187,9 +185,6 @@ export const RecordFileUpload = ({
           </div>
         </div>
       )}
-
-      {/* ToastContainer 실제 렌더링 */}
-      <GlobalToast />
     </div>
   )
 }

--- a/src/test/TestE.tsx
+++ b/src/test/TestE.tsx
@@ -1,7 +1,6 @@
 import { CreateStudyGroup } from '@/pages/study-groups/CreateStudyGroup'
 import { BasicModal } from '@/components/basicComponents/basicModal/BasicModal'
 import { createPortal } from 'react-dom'
-import { GlobalToast } from '@/components/basicComponents/toast/ToastContainer'
 
 export default function TestE() {
   // 아래줄 주석처리 후 링크 TestE 변경-생성 모드, 주석해제 후 링크 TestE 변경-수정 모드
@@ -34,8 +33,6 @@ export default function TestE() {
 
       {typeof document !== 'undefined' &&
         createPortal(<BasicModal />, document.body)}
-
-      <GlobalToast />
     </>
   )
 }

--- a/src/test/TestModal.tsx
+++ b/src/test/TestModal.tsx
@@ -1,7 +1,7 @@
 import { BasicButton } from '@/components/basicComponents/BasicButton/BasicButton'
-import { GlobalToast } from '@/components/basicComponents/toast/ToastContainer'
 import { useModal } from '@/hooks/useModal'
 import type { ModalPropsMap, ModalType } from '@/types/Modal'
+import { toast } from 'react-toastify'
 
 type ModalTestItem<T extends ModalType> = {
   modalType: T
@@ -48,7 +48,9 @@ function TestModal() {
 
   const options = {
     message: '리더를 위임하시겠습니까?',
-    onConfirm: closeModal,
+    onConfirm: () => {
+      toast.info('모달-토스트 테스트')
+    },
     onCancel: closeModal,
   }
 
@@ -69,8 +71,6 @@ function TestModal() {
         </BasicButton>
       ))}
       <BasicButton onClick={() => openConfirm(options)}>확인창</BasicButton>
-
-      <GlobalToast />
     </div>
   )
 }


### PR DESCRIPTION
## 💡 개요

- 기존에 GlobalToast-BasicModal 레이아웃 문제가 있던것을 확실하게 GlobalToast이 위에 뜨도록 수정함

## 📝 상세 내용

![Honeycam 2025-11-13 15-16-57](https://github.com/user-attachments/assets/0459fec8-c5c3-4c9b-be84-4d77d317f4fa)

- 두 컴포넌트 모두 동일하게 createPortal을 적용하고, GlobalToast은 BasicModal보다 z-index가 더 높도록 수정함

## ✅ 체크리스트

- [x] 코드에 불필요한 console.log 제거
- [x] lint 검사 통과
- [ ] 테스트 통과
- [ ] 관련 문서/README 업데이트

## 🔗 관련 이슈

- close #9 
