### PR TITLE
Fix modal - 데이트픽커 모달 null 방어로직 추가

### DIFF
--- a/src/components/modal/datePicker/DatePickerModal.tsx
+++ b/src/components/modal/datePicker/DatePickerModal.tsx
@@ -11,24 +11,29 @@ import type { ModalPropsMap } from '@/types/Modal'
 import { storeDatePicker } from '@/store/storeDatePicker'
 
 export const DatePickerModal = () => {
-  const [selected, setSelected] = useState<Date>()
-
-  const modalProps = storeModalOpen().modalState.modalProps
-
-  const target = (modalProps as ModalPropsMap['DATE_PICKER']).target
-
-  const { startDate, endDate, date, mode } = storeDatePicker()
-
   const today = dayjs().toDate()
   const [month, setMonth] = useState(dayjs(today).set('date', 1).toDate())
+  const [selected, setSelected] = useState<Date>()
+
+  const { startDate, endDate, date, mode } = storeDatePicker()
+  const { modalState } = storeModalOpen()
+
+  const modalProps = modalState.modalProps
+
+  const target = modalProps
+    ? (modalProps as ModalPropsMap['DATE_PICKER']).target
+    : null
 
   useEffect(() => {
+    if (!target) return
     if (target === 'start' && startDate) setSelected(startDate)
 
     if (target === 'end' && endDate) setSelected(endDate)
 
     if ((target === 'single' || mode === 'single') && date) setSelected(date)
   }, [target, startDate, endDate, date, mode])
+
+  if (!target) return null
 
   return (
     <motion.div

--- a/src/pages/study-groups/sections/PeriodSection.tsx
+++ b/src/pages/study-groups/sections/PeriodSection.tsx
@@ -19,6 +19,8 @@ export const PeriodSection = ({ form, setForm }: Props) => {
   const studyEndDate = endDate ? dayjs(endDate).format('L') : ''
 
   const handleOpenDatePicker = (type: 'start' | 'end') => {
+    // console.log(type)
+
     openModal('DATE_PICKER', {
       title: type === 'start' ? '스터디 시작일 선택' : '스터디 종료일 선택',
       modalProps: { target: type },


### PR DESCRIPTION
## 💡 개요

- null 방어로직 추가

## 📝 상세 내용

- 기존에 null 대응이 아예 안되어 날짜 선택 후 모달 프롭스가 null값이 되어 랜더링 오류가 나던 문제가 발생함
- null일때는 유즈 이팩트와 랜더링을 작동하지 않도록 변경하여 오류에 대응함

## ✅ 체크리스트

- [x] 코드에 불필요한 console.log 제거
- [x] lint 검사 통과
- [ ] 테스트 통과
- [ ] 관련 문서/README 업데이트

## 🔗 관련 이슈

- close #9 
