### PR TITLE
fix:chat 웹소캣 추가

### DIFF
--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -8,15 +8,12 @@ import type { AxiosRequestConfig } from 'axios'
 // 추후 실제 주소로 교체
 export const BASE_URL = import.meta.env.VITE_API_BASE_URL
 export const LOGIN_PAGE_URL = '/login'
-const WEB_SOCKET_URL = '/ws'
 
-const tokenManager = new TokenManager()
-const apiFactory = new ApiClientFactory(tokenManager)
+export const tokenManager = new TokenManager()
+export const apiFactory = new ApiClientFactory(tokenManager)
 
 const httpClient = apiFactory.createHttpClient(BASE_URL, throwHttpError)
 const requestExecutor = httpClient.getRequestExecutor()
 
 // 일반 http 통신은 트리 구조로 접근
 export const api = keyIsLink<ApiLinks, AxiosRequestConfig>(requestExecutor)
-// 웹소켓은 http 통신이 아니므로 따로 처리
-export const wsApi = apiFactory.createWebSocketClient(WEB_SOCKET_URL)

--- a/src/api/apiClient.ts
+++ b/src/api/apiClient.ts
@@ -29,7 +29,7 @@ export class ApiClientFactory {
   ): WebSocketClient {
     return new WebSocketClient({
       url,
-      tokenStorage: this.tokenStorage,
+      tokenManager: this.tokenStorage,
       ...callbacks,
     })
   }

--- a/src/api/wsClient.ts
+++ b/src/api/wsClient.ts
@@ -1,121 +1,106 @@
 import type { TokenStorage } from './tokenManager'
 import { LOGIN_PAGE_URL } from './api'
 import { refreshAccessToken } from './refreshAccessToken'
+import { storeChat } from '@/store/storeChat'
 
 export interface WebSocketClientConfig {
   url: string
-  tokenStorage: TokenStorage
+  tokenManager: TokenStorage
+  reconnect?: boolean
+  reconnectInterval?: number
+
   onOpen?: (event: Event) => void
   onMessage?: (event: MessageEvent) => void
   onError?: (event: Event) => void
   onClose?: (event: CloseEvent) => void
-  reconnect?: boolean
-  reconnectInterval?: number
 }
 
 // TODO : toast 알림 로직 작성 필요
 // TODO : 실제 로그인 페이지로 연결해야됨
 export class WebSocketClient {
   private ws: WebSocket | null = null
-  private url: string
-  private tokenStorage: TokenStorage
   private config: WebSocketClientConfig
   private reconnectAttempts: number = 0
   private maxReconnectAttempts: number = 5
   private reconnectTimer: number | null = null
+  private messageQueue: (string | ArrayBufferLike | Blob | ArrayBufferView)[] =
+    []
 
   constructor(config: WebSocketClientConfig) {
-    this.url = config.url
-    this.tokenStorage = config.tokenStorage
     this.config = config
   }
 
-  public async connect(): Promise<void> {
+  public async connect() {
+    // this.log('config in connect', this.config)
+    await this.initializeConnection()
+  }
+
+  private async initializeConnection() {
     this.clearPrev()
 
-    let token = this.tokenStorage.getAccessToken()
-
-    // 토큰 없으면 리프레시
-    if (!token) {
-      const success = await this.tryRefreshToken()
-      if (!success) return
-      token = this.tokenStorage.getAccessToken()
-    }
-
-    const wsUrl = token ? `${this.url}?token=${token}` : this.url
+    const token = await this.prepareToken()
+    const wsUrl = this.buildUrl(token)
+    // this.log('wsUrl in initializeConnection', wsUrl)
 
     this.ws = new WebSocket(wsUrl)
 
     this.ws.onopen = (event) => {
       this.reconnectAttempts = 0
-      if (this.config.onOpen) {
-        this.config.onOpen(event)
-      }
+      // this.log('onopen', {
+      //   url: wsUrl,
+      //   readyState: this.ws?.readyState,
+      //   timestamp: Date.now(),
+      // })
+      this.flushQueue()
+
+      this.config.onOpen?.(event)
     }
 
     this.ws.onmessage = (event) => {
-      if (this.config.onMessage) {
-        this.config.onMessage(event)
+      const data = JSON.parse(event.data)
+
+      switch (data.type) {
+        case 'chat.message':
+          this.config.onMessage?.(event)
+          break
+
+        case 'online.users':
+          // 온라인 사용자 업데이트
+          storeChat.getState().setOnlineUsers(data.users)
+          break
+
+        default:
+          this.log('Unknown WS event:', data)
       }
     }
 
     this.ws.onerror = (event) => {
-      if (this.config.onError) {
-        this.config.onError(event)
-      }
+      this.log('onerror', {
+        event,
+        readyState: this.ws?.readyState,
+        timestamp: Date.now(),
+      })
+      this.config.onError?.(event)
     }
 
-    this.ws.onclose = async (event) => {
-      if (this.config.onClose) {
-        this.config.onClose(event)
-      }
-
-      // 토큰 만료 감지 (서버에서 code 4001로 보낸다고 가정)
-      // TODO:실제 서버 코드로 변경 해야함
-      // 명세서에 없음
-      if (event.code === 4001) {
-        this.reconnectAttempts++
-        if (this.reconnectAttempts >= this.maxReconnectAttempts) {
-          this.tokenStorage.clearTokens()
-          window.location.href = LOGIN_PAGE_URL
-          return
-        }
-        const success = await this.tryRefreshToken()
-        if (success) {
-          await this.connect() // 성공 시 재연결
-          return
-        }
-        return
-      }
-
-      if (
-        this.config.reconnect &&
-        this.reconnectAttempts < this.maxReconnectAttempts
-      ) {
-        this.reconnectAttempts++
-        const interval = this.config.reconnectInterval || 3000
-
-        this.reconnectTimer = window.setTimeout(() => {
-          // console.log(
-          //   `WebSocket 재연결 시도 ${this.reconnectAttempts}/${this.maxReconnectAttempts}`
-          // )
-          // toast 연결 필요
-          this.connect()
-        }, interval)
-      }
+    this.ws.onclose = (event) => {
+      this.config.onClose?.(event)
+      this.handleClose(event)
     }
   }
 
   private clearPrev() {
     if (this.reconnectTimer) {
-      window.clearTimeout(this.reconnectTimer)
+      clearTimeout(this.reconnectTimer)
       this.reconnectTimer = null
     }
+
     if (this.ws) {
       this.ws.onopen = null
       this.ws.onmessage = null
       this.ws.onerror = null
       this.ws.onclose = null
+
       if (
         this.ws.readyState === WebSocket.OPEN ||
         this.ws.readyState === WebSocket.CONNECTING
@@ -125,55 +110,77 @@ export class WebSocketClient {
     }
   }
 
+  private buildUrl(token: string | null): string {
+    const separator = this.config.url.includes('?') ? '&' : '?'
+    return token
+      ? `${this.config.url}${separator}token=${token}`
+      : this.config.url
+  }
+
+  private async prepareToken(): Promise<string | null> {
+    let token = this.config.tokenManager.getAccessToken()
+
+    if (!token) {
+      const ok = await this.tryRefreshToken()
+      if (!ok) return null
+      token = this.config.tokenManager.getAccessToken()
+    }
+
+    return token
+  }
+
+  private handleClose(closeEvent: CloseEvent) {
+    this.log('onclose', closeEvent)
+    if (!this.config.reconnect) return
+    if (this.reconnectAttempts >= this.maxReconnectAttempts) return
+
+    this.reconnectAttempts++
+
+    this.reconnectTimer = window.setTimeout(() => {
+      this.connect()
+    }, this.config.reconnectInterval ?? 3000)
+  }
+
   private async tryRefreshToken(): Promise<boolean> {
     try {
       const newToken = await refreshAccessToken()
       if (newToken) {
-        this.tokenStorage.setAccessToken(newToken)
+        this.config.tokenManager.setAccessToken(newToken)
         return true
       }
-      throw new Error('Refresh failed')
+      throw new Error()
     } catch {
-      this.tokenStorage.clearTokens()
+      this.config.tokenManager.clearTokens()
       window.location.href = LOGIN_PAGE_URL
       return false
     }
   }
 
-  public send(data: string | ArrayBufferLike | Blob | ArrayBufferView): void {
-    if (this.ws && this.ws.readyState === WebSocket.OPEN) {
+  public send(data: string | ArrayBufferLike | Blob | ArrayBufferView) {
+    if (this.ws?.readyState === WebSocket.OPEN) {
       this.ws.send(data)
     } else {
-      // console.error('WebSocket이 연결되지 않았습니다.')
-      // toast 연결 필요
-      throw new Error(`WebSocket is not connected:${this.getReadyState()}`)
+      this.messageQueue.push(data)
     }
   }
 
-  public close(code?: number, reason?: string): void {
-    if (this.reconnectTimer) {
-      window.clearTimeout(this.reconnectTimer)
-      this.reconnectTimer = null
-    }
-
-    if (this.ws) {
-      this.ws.close(code, reason)
-      this.ws = null
+  private flushQueue() {
+    while (this.messageQueue.length > 0) {
+      this.ws?.send(this.messageQueue.shift()!)
     }
   }
 
-  /**
-   * 0: CONNECTING
-   * 1: OPEN
-   * 2: CLOSING
-   * 3: CLOSED
-   * null: 아직 생성되지 않음
-   */
-  public getReadyState(): number | null {
-    return this.ws ? this.ws.readyState : null
+  public close(code?: number, reason?: string) {
+    this.clearPrev()
+    this.ws?.close(code, reason)
+    this.ws = null
   }
 
-  public isConnected(): boolean {
-    return this.ws !== null && this.ws.readyState === WebSocket.OPEN
+  public isConnected() {
+    return this.ws?.readyState === WebSocket.OPEN
+  }
+
+  private log(...args: any[]) {
+    console.log('[WS]', ...args)
   }
 }

--- a/src/components/chat/ChatButton.tsx
+++ b/src/components/chat/ChatButton.tsx
@@ -30,7 +30,7 @@ export const ChatButton = () => {
           <>
             {totalUnreadCount !== 0 && (
               <div className="center-center bg-danger-500 absolute -top-2 left-12 h-6 w-6 rounded-full text-xs font-semibold text-white">
-                {totalUnreadCount}
+                {totalUnreadCount < 100 ? totalUnreadCount : '99+'}
               </div>
             )}
 

--- a/src/components/chat/ChatButton.tsx
+++ b/src/components/chat/ChatButton.tsx
@@ -51,10 +51,10 @@ const GETChatRooms = () => {
   const { setChatRooms } = storeChat()
   useAsyncEffect({
     asyncFn: async () => await api.v1.chat.chatrooms.GET(),
-    onSuccess: (data) => {
-      // console.log(data)
+    onSuccess: (chatRoomsData) => {
+      // console.log(chatRoomsData)
 
-      return setChatRooms(data || [])
+      return setChatRooms(chatRoomsData || [])
     },
     deps: [user],
   })

--- a/src/components/chat/ChatMessagesPanel.tsx
+++ b/src/components/chat/ChatMessagesPanel.tsx
@@ -11,9 +11,8 @@ import { useEffect, useLayoutEffect, useRef, useState } from 'react'
 import { toast } from 'react-toastify'
 
 // TODO
-// 1. 현재 사용자가 누구인지 파악하는 로직이 없음
-//    더미데이터의 세션 첫번째 유저가 사용자인것으로 가정하고 작성함
-//    추후에 수정 필요
+// 1. 멤버 구분(온라인/오프라인) 필드가 아예 없음
+//    스웨거, 명세서, 실제 데이터 어디에도 없음
 export const ChatMessagesPanel = () => {
   const { currentChatRoomUUID } = storeChat()
 

--- a/src/components/chat/ChatMessagesPanel.tsx
+++ b/src/components/chat/ChatMessagesPanel.tsx
@@ -42,8 +42,12 @@ const GETChatMessages = ({
       if (!currentChatRoomUUID) return
       return await api.v1.chat.chatrooms(currentChatRoomUUID).messages.GET()
     },
-    onSuccess: (data) => data && setMessages(data.data.messages),
-    deps: [],
+    onSuccess: (chatMessageData) => {
+      // console.log({ chatMessageData })
+
+      return chatMessageData && setMessages(chatMessageData.results)
+    },
+    deps: [currentChatRoomUUID],
   })
   return null
 }
@@ -184,7 +188,8 @@ const ChatMessages = () => {
 
 const Message = ({ message }: { message: ChatMessage }) => {
   const { user } = storeUser()
-  if (!user) return
+  // 서버쪽 더미데이터에 sender가 null 인 경우도 있음
+  if (!user || !message.sender) return
 
   const isMe = message.sender.id === user?.id
 
@@ -222,6 +227,7 @@ const Message = ({ message }: { message: ChatMessage }) => {
 
 const ChatInput = () => {
   const { addMessage } = storeChat()
+  const { currentChatRoomUUID } = storeChat()
   const { user } = storeUser()
 
   const ref = useRef<HTMLTextAreaElement>(null)
@@ -235,14 +241,14 @@ const ChatInput = () => {
     }
   }, [text])
 
-  if (!user) return
+  if (!user || !currentChatRoomUUID) return
   const me = { id: user.id, nickname: user.nickname }
 
   const newChat: ChatMessage = {
+    study_group_uuid: currentChatRoomUUID,
     id: Date.now(),
     sender: me,
     content: text,
-    is_read: true,
     created_at: new Date().toISOString(),
   }
 

--- a/src/components/chat/ChatMessagesPanel.tsx
+++ b/src/components/chat/ChatMessagesPanel.tsx
@@ -3,27 +3,39 @@ import { useAsyncEffect } from '@/hooks/useAsyncEffect'
 import { formatToHourMin } from '@/hooks/useFormatDate'
 import { storeChat } from '@/store/storeChat'
 import { storeUser } from '@/store/storeUser'
-import type { ChatMessage } from '@/types/Chat'
+import { storeWs } from '@/store/storeWS'
+import type { chatMember, ChatMessage } from '@/types/Chat'
 import clsx from 'clsx'
 import { motion } from 'framer-motion'
 import { ArrowLeft, Send, X } from 'lucide-react'
 import { useEffect, useLayoutEffect, useRef, useState } from 'react'
-import { toast } from 'react-toastify'
+// import { toast } from 'react-toastify'
 
 // TODO
-// 1. 멤버 구분(온라인/오프라인) 필드가 아예 없음
-//    스웨거, 명세서, 실제 데이터 어디에도 없음
+// 현재 채팅 방 정보 받아왔을때 온라인인 유저 정보 보기 없음
+// 채팅 메시지 받아오기에서 전체 멤버 없음
+// 웹 소캣 연결시 온라인은 유저만 받아올수 있음
 export const ChatMessagesPanel = () => {
   const { currentChatRoomUUID } = storeChat()
+  const { connect, disconnect } = storeWs()
 
   useEffect(() => {
     if (!currentChatRoomUUID) return
+
+    connect(currentChatRoomUUID)
+
+    return () => {
+      disconnect()
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [currentChatRoomUUID])
+
   return (
     <>
       <GETChatMessages currentChatRoomUUID={currentChatRoomUUID} />
+
       <ChatHeader />
-      {/* <ChatMembers /> */}
+      <ChatMembers />
       <ChatMessages />
       <ChatInput />
     </>
@@ -68,16 +80,12 @@ const ChatHeader = () => {
     setIsPanelOpen(false)
   }
 
-  // const onlineMemberCount =
-  //   session?.member.filter((id) => {
-  //     const user = dummyUsers.find((u) => u.id === id)
-  //     return user?.is_online
-  //   }).length ?? 0
+  const onlineMemberCount = storeChat().chatMembers.length
 
-  // const onlineDot = clsx('w-2 h-2 rounded-full', {
-  //   'bg-gray-300': onlineMemberCount === 0,
-  //   'bg-[#22C55E]': onlineMemberCount !== 0,
-  // })
+  const onlineDot = clsx('w-2 h-2 rounded-full', {
+    'bg-gray-300': onlineMemberCount === 0,
+    'bg-[#22C55E]': onlineMemberCount !== 0,
+  })
 
   const closeButton = clsx(
     'center-center h-8 w-8 cursor-pointer rounded-md transition-colors hover:bg-gray-100'
@@ -92,12 +100,12 @@ const ChatHeader = () => {
         <div className="flex h-9 flex-col pl-2">
           <span className="text-sm font-semibold">{currentChatRoom?.name}</span>
           <div className="flex h-4 flex-row items-center gap-1">
-            {/* <span className={onlineDot} />
+            <span className={onlineDot} />
             <span className="font-roboto text-xs text-gray-600">
               {onlineMemberCount === 0
                 ? `0명 온라인`
                 : `${onlineMemberCount}명 온라인`}
-            </span> */}
+            </span>
           </div>
         </div>
       </div>
@@ -108,56 +116,51 @@ const ChatHeader = () => {
   )
 }
 
-// const ChatMembers = () => {
-//   const {  currentChatRoomUUID,  chatRooms } =
-//     storeChat()
-//   const session = chatRooms.find((s) => s.uuid === currentChatRoomUUID)
-//   const membersRef = useRef<HTMLDivElement>(null)
+const ChatMembers = () => {
+  const membersRef = useRef<HTMLDivElement>(null)
 
-//   const members: ChatUser[] =
-//     session?.member
-//       .map((userId) => dummyUsers.find((user) => user.id === userId))
-//       .filter((user): user is ChatUser => user !== undefined) ?? []
+  const { chatMembers } = storeChat()
 
-//   const handleWheel = (e: React.WheelEvent) => {
-//     if (membersRef.current) {
-//       membersRef.current.scrollLeft += e.deltaY
-//     }
-//   }
+  const handleWheel = (e: React.WheelEvent) => {
+    if (membersRef.current) {
+      membersRef.current.scrollLeft += e.deltaY
+    }
+  }
 
-//   return (
-//     <div
-//       ref={membersRef}
-//       onWheel={handleWheel}
-//       className="transparent-scrollbar-x h-[41px] border-b border-gray-200 bg-gray-50 px-2"
-//     >
-//       <div className="inline-flex h-full flex-row items-center gap-2">
-//         {members.map((el, idx) => (
-//           <Member member={el} isMe={idx === 0} key={el.id} />
-//         ))}
-//       </div>
-//     </div>
-//   )
-// }
+  return (
+    <div
+      ref={membersRef}
+      onWheel={handleWheel}
+      className="transparent-scrollbar-x h-[41px] border-b border-gray-200 bg-gray-50 px-2"
+    >
+      <div className="inline-flex h-full flex-row items-center gap-2">
+        {chatMembers.map((el, idx) => (
+          <Member member={el} isMe={idx === 0} key={el.id} />
+        ))}
+      </div>
+    </div>
+  )
+}
 
-// const Member = ({ member, isMe }: { member: ChatUser; isMe: boolean }) => {
-//   const onlineDot = clsx('w-2 h-2 rounded-full', {
-//     'bg-gray-300': !member.is_online,
-//     'bg-[#4ADE80]': member.is_online,
-//   })
+// 전체 멤버 받아오는 로직 없음
+const Member = ({ member, isMe }: { member: chatMember; isMe: boolean }) => {
+  const onlineDot = clsx('w-2 h-2 rounded-full bg-[#4ADE80]', {
+    // 'bg-gray-300': !member.is_online,
+    // 'bg-[#4ADE80]': member.is_online,
+  })
 
-//   const nickName = clsx('text-xs font-roboto center-center whitespace-nowrap', {
-//     'text-primary-600': isMe,
-//     'text-gray-700': !isMe,
-//   })
+  const nickName = clsx('text-xs font-roboto center-center whitespace-nowrap', {
+    'text-primary-600': isMe,
+    'text-gray-700': !isMe,
+  })
 
-//   return (
-//     <div className="flex h-6 flex-row items-center gap-1 rounded-full bg-white px-2 py-1">
-//       <span className={onlineDot} />
-//       <span className={nickName}>{member.nickName}</span>
-//     </div>
-//   )
-// }
+  return (
+    <div className="flex h-6 flex-row items-center gap-1 rounded-full bg-white px-2 py-1">
+      <span className={onlineDot} />
+      <span className={nickName}>{member.nickname}</span>
+    </div>
+  )
+}
 
 const ChatMessages = () => {
   const { messages } = storeChat()
@@ -190,7 +193,11 @@ const Message = ({ message }: { message: ChatMessage }) => {
   // 서버쪽 더미데이터에 sender가 null 인 경우도 있음
   if (!user || !message.sender) return
 
-  const isMe = message.sender.id === user?.id
+  const isMe = Number(message.sender.id) === user.id
+
+  // console.log(message)
+  // console.log(user)
+  // console.log(isMe)
 
   const sender = message.sender
 
@@ -225,12 +232,13 @@ const Message = ({ message }: { message: ChatMessage }) => {
 }
 
 const ChatInput = () => {
-  const { addMessage } = storeChat()
+  const { sendMessage } = storeWs()
   const { currentChatRoomUUID } = storeChat()
   const { user } = storeUser()
 
-  const ref = useRef<HTMLTextAreaElement>(null)
   const [text, setText] = useState('')
+
+  const ref = useRef<HTMLTextAreaElement>(null)
   const [height, setHeight] = useState(38)
 
   useLayoutEffect(() => {
@@ -241,30 +249,21 @@ const ChatInput = () => {
   }, [text])
 
   if (!user || !currentChatRoomUUID) return
-  const me = { id: user.id, nickname: user.nickname }
+  const handleSend = () => {
+    if (!text.trim()) return
 
-  const newChat: ChatMessage = {
-    study_group_uuid: currentChatRoomUUID,
-    id: Date.now(),
-    sender: me,
-    content: text,
-    created_at: new Date().toISOString(),
-  }
+    sendMessage({
+      type: 'chat.message',
+      content: text,
+    })
 
-  const handleSubmit = () => {
-    try {
-      addMessage(newChat)
-    } catch (error) {
-      toast.error(`메시지 전송 중 에러가 발생했습니다:${error}`)
-    } finally {
-      setText('')
-    }
+    setText('')
   }
 
   const handleKeyUp = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
     if (e.key === 'Enter' && !e.shiftKey) {
       e.preventDefault()
-      handleSubmit()
+      handleSend()
     }
   }
 
@@ -282,7 +281,7 @@ const ChatInput = () => {
         className="transparent-scrollbar max-h-[200px] w-[254px] resize-none overflow-hidden rounded-[19px] border border-gray-300 bg-white px-3 py-2 leading-5 text-gray-700 caret-gray-400 outline-none placeholder:text-gray-400"
       />
       <div
-        onClick={handleSubmit}
+        onClick={handleSend}
         className="center-center h-8 w-8 cursor-pointer rounded-full bg-gray-300 transition-colors hover:bg-gray-400"
       >
         <Send size={20} className="text-white" />

--- a/src/store/storeChat.ts
+++ b/src/store/storeChat.ts
@@ -1,4 +1,4 @@
-import type { ChatMessage, chatPanel, ChatRoom } from '@/types/Chat'
+import type { chatMember, ChatMessage, chatPanel, ChatRoom } from '@/types/Chat'
 import { create } from 'zustand'
 import { subscribeWithSelector } from 'zustand/middleware'
 
@@ -9,6 +9,7 @@ interface storeChat {
   messages: ChatMessage[]
   chatRooms: ChatRoom[]
   totalUnreadCount: number
+  chatMembers: chatMember[]
 
   setIsPanelOpen: (isOpen: boolean) => void
   setCurrentPanel: (panel: chatPanel) => void
@@ -16,6 +17,7 @@ interface storeChat {
   addMessage: (message: ChatMessage) => void
   setChatRooms: (chatRooms: ChatRoom[]) => void
   togglePanel: (studyGroupUUID?: string) => void
+  setOnlineUsers: (users: chatMember[]) => void
 }
 
 // 헬퍼 함수
@@ -31,6 +33,7 @@ export const storeChat = create<storeChat>()(
       chatRooms: [],
       messages: [],
       totalUnreadCount: 0,
+      chatMembers: [],
 
       setIsPanelOpen: (isOpen) => set({ isPanelOpen: isOpen }),
       setCurrentPanel: (panel) => set({ currentPanel: panel }),
@@ -50,6 +53,7 @@ export const storeChat = create<storeChat>()(
           currentChatRoomUUID:
             state.currentPanel === 'sessions' ? studyGroupUUID : null,
         })),
+      setOnlineUsers: (users) => set({ chatMembers: users }),
     }
   })
 )

--- a/src/store/storeWS.ts
+++ b/src/store/storeWS.ts
@@ -1,0 +1,48 @@
+// store/wsStore.ts
+import { create } from 'zustand'
+import { storeChat } from './storeChat'
+import { tokenManager } from '@/api/api'
+import { WebSocketClient } from '@/api/wsClient'
+
+type MessageCLtoSe = {
+  type: string
+  content: string
+}
+
+interface StoreWs {
+  ws: WebSocketClient | null
+  connect: (roomUUID: string) => void
+  sendMessage: (msg: MessageCLtoSe) => void
+  disconnect: () => void
+}
+
+export const storeWs = create<StoreWs>((set, get) => ({
+  ws: null,
+
+  connect: async (roomUUID: string) => {
+    const client = new WebSocketClient({
+      url: `wss://api.ozcoding.site/ws/chat/${roomUUID}/`,
+      tokenManager,
+      reconnect: true,
+      reconnectInterval: 3000,
+
+      onMessage: (event) => {
+        const data = JSON.parse(event.data)
+        storeChat.getState().addMessage(data)
+      },
+    })
+
+    client.connect()
+    set({ ws: client })
+  },
+
+  sendMessage: (msg) => {
+    const ws = get().ws
+    ws?.send(JSON.stringify(msg))
+  },
+
+  disconnect: () => {
+    get().ws?.close()
+    set({ ws: null })
+  },
+}))

--- a/src/test/TestG.tsx
+++ b/src/test/TestG.tsx
@@ -1,5 +1,6 @@
-import { api } from '@/api/api'
+// import { apiFactory } from '@/api/api'
 import { BasicButton } from '@/components/basicComponents/BasicButton/BasicButton'
+import { storeAccessToken } from '@/store/storeAccessToken'
 // import { toast } from 'react-toastify'
 
 // const serverDummyGroupUUid = '57c71ffc-1a31-484f-8807-8fb985f63e7b'
@@ -80,6 +81,7 @@ import { BasicButton } from '@/components/basicComponents/BasicButton/BasicButto
 
 // const params = { page: 1 }
 const TestG = () => {
+  const { accessToken } = storeAccessToken()
   const handleClick = async () => {
     try {
       // const res = await api.v1.lectures.GET()
@@ -90,17 +92,14 @@ const TestG = () => {
       // const res = await api.v1.studies.groups(444).members(555).DELETE()
       // const res = await api.v1.studies.groups.POST(dummyStudyGroup)
       // const res = await api.v1.studies.groups.GET(undefined, { params })
-
       // const res = await api.v1.studies
       //   .groups('57c71ffc-1a31-484f-8807-8fb985f63e7b')
       //   .reviews.GET(undefined, {
       //     params: reviewParams,
       //   })
-
       // const res = await api.v1.studies
       //   .groups(serverDummyGroupUUid)
       //   .reviews.GET()
-
       // api.v1.studies.groups(params.groupId).reviews.GET(undefined, {
       //   params: {
       //     page: params.page,
@@ -108,9 +107,7 @@ const TestG = () => {
       //     ordering: params.ordering,
       //   },
       // })
-
       // const res = await api.v1.chat.chatrooms.GET()
-
       // const res = await api.v1.studies.groups(serverDummyGroupUUid).GET()
       // const res = await api.v1.studies
       //   .groups(serverDummyGroupUUid)
@@ -122,10 +119,12 @@ const TestG = () => {
       //   .kick$member.DELETE({
       //     target_member_uuid: serverDummyGroupMemberUUid[9].uuid,
       //   })
-
-      const res = await api.v1.studies.groups.POST()
+      // const res = await api.v1.studies.groups.POST()
       // const res = await api.v1.studies.groups(serverDummyGroupUUid).GET()
-      console.log(res)
+
+      console.log({ accessToken })
+
+      // console.log(res)
       // toast.info(`${res}`)
     } catch (error) {
       console.error('API call failed:', error)

--- a/src/types/ApiLink.ts
+++ b/src/types/ApiLink.ts
@@ -336,21 +336,6 @@ type ScheduleDetail = Schedule & {
   participants: Participant[]
 }
 
-// ===================== Chat =====================
-type PaginatedChats = {
-  status: string
-  code: string
-  message: string
-  data: {
-    messages: ChatMessage[]
-    pagination: {
-      page: number
-      page_size: number
-      total_count: number
-    }
-  }
-}
-
 // ===================== Pagination =====================
 export type PageReq = { page: number }
 
@@ -631,8 +616,10 @@ type ChatApi = {
         // 스웨거에는 ChatMessage 만 적혀있음
         // 페이지 옵션과 데이터 결과가 매우 이질적으로 되어 있음
         // 이것만 따로 데이터 구조 다르게 기입함
+
+        // 25.11.16 실제 오는 데이터를 기준으로 수정함
         GET: () => {
-          res: PaginatedChats
+          res: Pagination<ChatMessage>
         }
       }
     }

--- a/src/types/Chat.ts
+++ b/src/types/Chat.ts
@@ -1,11 +1,9 @@
 export type chatPanel = 'sessions' | 'messages'
 
-type UserId = number
-
-export type ChatUser = {
-  id: UserId
-  is_online: boolean
-  nickName: string
+export type chatMember = {
+  id: number
+  nickname: string
+  name: string
 }
 
 type ChatSender = {

--- a/src/types/Chat.ts
+++ b/src/types/Chat.ts
@@ -14,11 +14,11 @@ type ChatSender = {
 }
 
 export type ChatMessage = {
+  content: string
+  created_at: string
   id: number
   sender: ChatSender
-  content: string
-  is_read: boolean
-  created_at: string
+  study_group_uuid: string
 }
 
 type LastMessage = {


### PR DESCRIPTION
## 💡 개요

- 채팅 메시지 api 응답 구조가 스웨거, 명세서, 실제 데이터 전부 다름
- 실제 오는 데이터대로 변경함

- 채팅 웹소켓 기능 추가

## 📝 상세 내용

- src\types\Chat.ts 의 ChatMessage 타입 수정 및 api 검증 완료
  - [명세서](https://www.notion.so/Chat_04_WebSocket-API-28dcaf5650aa806883c2e9ac8bfc55bd)상엔 `study_group_id 제거: 중복 정보를 제거하여 페이로드를 경량화` 라고 적혀 있고, 이게 올바른 방향인것 같으나 실제 데이터에선 study_group_id 포함됨
- 현재 명세서, 스웨거에서 온라인/오프라인 멤버 구분이나, 채팅방에 소속된 멤버 가져오는 로직이 아예 없음
  - 명세서, 스웨거, 실제 데이터(채팅방 조회, 채팅 메시지 조회 모두) 어디에도 멤버 필드 자체가 없음
- 실제 데이터에서 어떤 목적으로 ChatMessage 의 sender 필드를 nullable로 했는지는 모르겠으나, 해당 경우엔 랜더링 자체가 안되도록 방어로직을 작성함

![Honeycam 2025-11-16 19-06-39](https://github.com/user-attachments/assets/2e3734cc-f2cb-4ffb-ae3d-7a1fe5ea2d87)

- 웹소켓 기능 테스트
- 명세서상 웹 소켓 기능이 제대로 기입 되지 않은 상태에서 실제 데이터만 뜯어보고 작성했음
- 추후에 변경될 가능성 매우 높음
```ts
{
    "type": "chat.message",
    "id": "444",
    "content": "251116 웹소캣 테스트",
    "created_at": "2025-11-16T09:43:46.997611+00:00",
    "sender": {
        "id": "1",
        "nickname": "admin"
    }
}
```
- 위와 같이 소켓 연결했을때 오는 메시지만 유일하게 sender.id 가 string 타입임
- 나머지 모든 sender, user 데이터는 id가 number임
- api.v1.chat.chatrooms(currentChatRoomUUID).messages.GET()으로 받아오는 메시지들도 모두 sender.id가 number 타입임
- 현재 Number() 메서드로 방어로직을 짰으나, 이후에 변경 가능성 있음

## ✅ 체크리스트

- [x] 코드에 불필요한 console.log 제거
- [x] lint 검사 통과
- [ ] 테스트 통과
- [ ] 관련 문서/README 업데이트

## 🔗 관련 이슈

- close #7 #6 
