### PR TITLE
fix: 스터디그룹 검색 결과가 없을 때 컴포넌트

### DIFF
--- a/src/components/searchStudy/NoStudiesResult.tsx
+++ b/src/components/searchStudy/NoStudiesResult.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import { Users } from 'lucide-react'
 import { BasicButton } from '@/components/basicComponents/BasicButton/BasicButton'
 import test1 from '../../../public/icons/medal.svg'
+import { useNavigate } from 'react-router'
 
 // StudyType타입에 active와 completed라는 상태를 정의
 type StudyType = 'active' | 'completed'
@@ -28,6 +29,11 @@ export const NoStudiesResult = ({
   type,
   isSearchResult = false,
 }: NoStudiesResultProps) => {
+  const navigate = useNavigate()
+
+  const handleClickCreateStudy = () => {
+  navigate('/create_study_group')
+}
   // 타입 매핑 (키에 따라 서로 다른 상태 설정을 매핑하는 객체)
   // Record< K:키(StudyType), T:타입(StatusConfig) > 유틸리티 타입.
   // K:진행중인 스터디가 없을 때 or  완료된 스터디가 없을 때
@@ -67,10 +73,17 @@ export const NoStudiesResult = ({
         <h3 className="mb-2 text-xl font-bold text-gray-900">{displayTitle}</h3>
         <p className="mb-6 text-gray-600">{currentStatus.description}</p>
         {currentStatus.showButton && (
-          <BasicButton variant="primary" size="large">
+          <BasicButton variant="primary" size="large" onClick={handleClickCreateStudy}>
             <span className="mr-2 text-xl">+</span>
             <span>스터디 그룹 만들기</span>
           </BasicButton>
+        //           <BasicButton
+        //   variant="primary"
+        //   onClick={handleClickCreateStudy}
+        //   size="medium"
+        // >
+        //   <Plus size={16} /> 새 스터디 만들기
+        // </BasicButton>
         )}
       </section>
   )


### PR DESCRIPTION
    내부에서 스터디 그룹 만들기 버튼 페이지네이션(#154)

## 📌 제목

- fix: 스터디그룹 검색 결과가 없을 때 컴포넌트

## 💡 개요

- 
<img width="679" height="492" alt="클릭전" src="https://github.com/user-attachments/assets/83d7be53-4c2e-417a-90ac-4f047d9ef0fd" />

<img width="1656" height="1433" alt="이동후" src="https://github.com/user-attachments/assets/722a845e-eb89-43ab-ad87-c2a40d3df8cd" />

## 📝 상세 내용

- 스터디그룹 검색 결과가 없을 때 컴포넌트에서 스터디그룹 생성하기 페이지로 페이지네이션

## ✅ 체크리스트

- [ ] 코드에 불필요한 console.log 제거
- [ ] lint 검사 통과
- [ ] 테스트 통과
- [ ] 관련 문서/README 업데이트

## 🔗 관련 이슈

- close #154 이슈번호
