### PR TITLE
feat: 기록 상세페이지 api 연결 (#133)

### DIFF
--- a/src/hooks/api/queries/useQueryRecordDetail.ts
+++ b/src/hooks/api/queries/useQueryRecordDetail.ts
@@ -1,0 +1,16 @@
+import { api } from '@/api/api'
+import { queryKeys } from '../queryKeys'
+import { useQuery } from '@tanstack/react-query'
+
+export interface RecordDetailParams {
+  groupId: string
+  noteId: number
+}
+
+// (스웨거) 강의 목록 검색, 필터링, 정렬 조회 기능 누락
+export const useQueryRecordDetail = (params: RecordDetailParams) => {
+  return useQuery({
+    queryKey: queryKeys.studies.groups.notes(params.groupId),
+    queryFn: () => api.v1.studies.notes(params.noteId).GET(),
+  })
+}

--- a/src/pages/study-group-detail/StudyRecordList.tsx
+++ b/src/pages/study-group-detail/StudyRecordList.tsx
@@ -15,8 +15,8 @@ export const StudyRecordList = ({ groupId }: StudyRecordListProps) => {
     navigate(`/create_study_record/${groupId}`)
   }
 
-  const handleRecordClick = (recordId: number) => {
-    navigate(`/study-record/${recordId}`)
+  const handleRecordClick = (groupId: string, recordId: number) => {
+    navigate(`/study_record_detail/${groupId}/${recordId}`)
   }
 
   if (isPending) {
@@ -33,7 +33,9 @@ export const StudyRecordList = ({ groupId }: StudyRecordListProps) => {
     return (
       <div className="rounded-xl border border-gray-100 bg-white p-6">
         <div className="flex items-center justify-center py-8">
-          <div className="text-red-500">스터디 기록을 불러오는데 실패했습니다.</div>
+          <div className="text-red-500">
+            스터디 기록을 불러오는데 실패했습니다.
+          </div>
         </div>
       </div>
     )
@@ -49,7 +51,7 @@ export const StudyRecordList = ({ groupId }: StudyRecordListProps) => {
         <BasicButton
           variant="primary"
           size="small"
-          className="flex items-center gap-2 !px-4 !py-2 !text-sm text-white cursor-pointer"
+          className="flex cursor-pointer items-center gap-2 !px-4 !py-2 !text-sm text-white"
           onClick={handleWriteClick}
         >
           <img
@@ -64,8 +66,12 @@ export const StudyRecordList = ({ groupId }: StudyRecordListProps) => {
       {recordsList?.length === 0 ? (
         <div className="flex items-center justify-center py-12">
           <div className="text-center">
-            <p className="text-gray-500 mb-2">아직 작성된 스터디 기록이 없습니다.</p>
-            <p className="text-sm text-gray-400">첫 스터디 기록을 작성해보세요!</p>
+            <p className="mb-2 text-gray-500">
+              아직 작성된 스터디 기록이 없습니다.
+            </p>
+            <p className="text-sm text-gray-400">
+              첫 스터디 기록을 작성해보세요!
+            </p>
           </div>
         </div>
       ) : (
@@ -74,7 +80,7 @@ export const StudyRecordList = ({ groupId }: StudyRecordListProps) => {
             <div
               key={record.id}
               className="hover:border-primary-400 hover:bg-primary-50/40 group cursor-pointer rounded-xl border border-gray-200 transition-all"
-              onClick={() => handleRecordClick(record.id)}
+              onClick={() => handleRecordClick(groupId, record.id)}
             >
               <div className="flex items-center justify-between p-4">
                 <h3 className="group-hover:text-primary-700 text-[28px] text-gray-900">
@@ -101,7 +107,9 @@ export const StudyRecordList = ({ groupId }: StudyRecordListProps) => {
                       alt="파일 첨부"
                       className="filter: contrast-84; w-[8.5px] brightness-90 hue-rotate-182 invert-47 saturate-755 sepia-7"
                     />
-                    <p className="mt-1 text-xs text-gray-500">첨부파일 {record.files_count}개</p>
+                    <p className="mt-1 text-xs text-gray-500">
+                      첨부파일 {record.files_count}개
+                    </p>
                   </div>
                 </div>
               </div>

--- a/src/pages/study-records/StudyRecordDetail.tsx
+++ b/src/pages/study-records/StudyRecordDetail.tsx
@@ -1,16 +1,26 @@
 import { ArrowLeft } from 'lucide-react'
-import ReactMarkdown from 'react-markdown'
-import remarkGfm from 'remark-gfm'
 import { BasicButton } from '@/components/basicComponents/BasicButton/BasicButton'
 import { RecordBreadcrumb } from '@/components/breadcrumb/RecordBreadcrumb'
-import { dummyStudyRecordDetail } from '@/assets/dummyData/dummyStudyRecordDetail'
 import { StudyRecordHeader } from './sections/StudyRecordHeader'
 import { StudyRecordAISummary } from './sections/StudyRecordAISummary'
 import { StudyRecordAttachments } from './sections/StudyRecordAttachments'
+import { useQueryRecordDetail } from '@/hooks/api/queries/useQueryRecordDetail'
+import { useParams } from 'react-router'
+import { toast } from 'react-toastify'
 
 export const StudyRecordDetail = () => {
-  const { data } = dummyStudyRecordDetail
-  const { title, author, content, ai_summary, attachments, created_at } = data
+  const { studyGroupId, studyRecordId } = useParams()
+  const { data, error, isError, isPending } = useQueryRecordDetail(
+    studyRecordId && studyGroupId
+      ? { groupId: studyGroupId, noteId: Number(studyRecordId) }
+      : { groupId: '', noteId: 0 }
+  )
+  if (isPending) <div>로딩중...</div>
+  if (isError) toast.error(error.message)
+
+  const recordData = data && data.data.data
+
+  if (!recordData) return null
 
   const handleBack = () => {
     // TODO: 추후 navigate('/study-groups/ID') 등으로 연결 예정
@@ -23,24 +33,24 @@ export const StudyRecordDetail = () => {
       <div className="mt-4 overflow-hidden rounded-2xl border border-gray-200 bg-white">
         <section className="p-10">
           <StudyRecordHeader
-            title={title}
-            author={author}
-            created_at={created_at}
+            title={recordData.title}
+            author={recordData.author}
+            created_at={recordData.created_at}
           />
         </section>
 
         <section className="border-t border-gray-200 px-10 py-8">
-          <StudyRecordAISummary summaryData={ai_summary} />
+          <StudyRecordAISummary summaryData={recordData.ai_summary} />
         </section>
 
         <section className="border-t border-gray-200 px-10 py-8">
           <div className="prose prose-neutral max-w-none">
-            <ReactMarkdown remarkPlugins={[remarkGfm]}>{content}</ReactMarkdown>
+            <pre>{recordData.content}</pre>
           </div>
         </section>
 
         <section className="border-t border-gray-200 px-10 pt-0 pb-8">
-          <StudyRecordAttachments attachments={attachments} />
+          <StudyRecordAttachments attachments={recordData.attachments} />
         </section>
       </div>
 

--- a/src/pages/study-records/sections/StudyRecordAISummary.tsx
+++ b/src/pages/study-records/sections/StudyRecordAISummary.tsx
@@ -2,12 +2,13 @@ import { useState } from 'react'
 import { Eye, EyeOff } from 'lucide-react'
 
 interface AISummaryProps {
-  summaryData: {
-    title: string
-    summary: string
-    keywords: string[]
-    recommendations: string[]
-  }
+  // summaryData: {
+  //   title: string
+  //   summary: string
+  //   keywords: string[]
+  //   recommendations: string[]
+  // }
+  summaryData: string
 }
 
 export const StudyRecordAISummary = ({ summaryData }: AISummaryProps) => {
@@ -47,7 +48,8 @@ export const StudyRecordAISummary = ({ summaryData }: AISummaryProps) => {
 
       {isOpen && (
         <div className="rounded-xl bg-[#FEFCE8] p-6 text-gray-800">
-          <p className="mb-4">{summaryData.title}</p>
+          <p>{summaryData}</p>
+          {/* <p className="mb-4">{summaryData.title}</p>
 
           <div className="space-y-6">
             <section>
@@ -76,7 +78,7 @@ export const StudyRecordAISummary = ({ summaryData }: AISummaryProps) => {
                 ))}
               </ul>
             </section>
-          </div>
+          </div> */}
         </div>
       )}
     </div>

--- a/src/pages/study-records/sections/StudyRecordAttachments.tsx
+++ b/src/pages/study-records/sections/StudyRecordAttachments.tsx
@@ -1,10 +1,8 @@
+import type { NoteFile } from '@/types/Note'
 import { ArrowDownToLine } from 'lucide-react'
 
 interface AttachmentsProps {
-  attachments: {
-    filename: string
-    url: string
-  }[]
+  attachments: NoteFile[]
 }
 
 export const StudyRecordAttachments = ({ attachments }: AttachmentsProps) => {

--- a/src/types/ApiLink.ts
+++ b/src/types/ApiLink.ts
@@ -267,21 +267,21 @@ type NoteAuthor = {
   profile_image_url: string
 }
 
-type AISummary = {
-  available: boolean
-  created_at: string
-  format: string
-  body: string
-}
+// type AISummary = {
+//   available: boolean
+//   created_at: string
+//   format: string
+//   body: string
+// }
 
 type Note = {
   id: number
   group_id: string
   title: string
   author: NoteAuthor
-  content_md: string
+  content: string
   attachments: NoteFile[]
-  ai_summary: AISummary
+  ai_summary: string
   created_at: string
   updated_at: string
 }
@@ -574,7 +574,7 @@ type NoteApi = {
   POST: (req: NotePost) => { res: BaseResWithGeneric<NotePostRes> }
 
   (note_id: number): {
-    GET: () => { res: BaseResWithGeneric<Note> }
+    GET: () => { res: { data: BaseResWithGeneric<Note> } }
     PATCH: (req: NotePatchReq) => { res: BaseResWithGeneric<Note> }
     DELETE: () => { res: BaseResponse }
   }

--- a/src/types/Note.ts
+++ b/src/types/Note.ts
@@ -1,0 +1,23 @@
+export type NoteFile = {
+  type: string
+  url: string
+  filename: string | null
+}
+
+type NoteAuthor = {
+  id: number
+  nickname: string
+  profile_image_url: string
+}
+
+export type Note = {
+  id: number
+  group_id: string
+  title: string
+  author: NoteAuthor
+  content: string
+  attachments: NoteFile[]
+  ai_summary: string
+  created_at: string
+  updated_at: string
+}


### PR DESCRIPTION
## 📌 제목

- feat: 기록 상세페이지 api 연결 (#133)

## 💡 개요

- 학습기록 상세 페이지 api 연결하여 실제 데이터를 보여준다.

## 📝 상세 내용

- 학습기록 상세 조회 api 연결
- api 데이터에 맞게 타입 변경

## ✅ 체크리스트

- [ ] 코드에 불필요한 console.log 제거
- [ ] lint 검사 통과
- [ ] 테스트 통과
- [ ] 관련 문서/README 업데이트

## 🔗 관련 이슈

- close #133 
