### PR TITLE
fix:채팅 방 진입시 채팅방 목록을 다시 불러오도록 변경

### DIFF
--- a/src/components/chat/ChatButton.tsx
+++ b/src/components/chat/ChatButton.tsx
@@ -7,6 +7,7 @@ import { AnimatePresence } from 'framer-motion'
 import { useAsyncEffect } from '@/hooks/useAsyncEffect'
 import { api } from '@/api/api'
 import { storeUser } from '@/store/storeUser'
+import { storeWs } from '@/store/storeWS'
 
 export const ChatButton = () => {
   const { totalUnreadCount, setIsPanelOpen, isPanelOpen } = storeChat()
@@ -49,6 +50,7 @@ export const ChatButton = () => {
 const GETChatRooms = () => {
   const { user } = storeUser()
   const { setChatRooms } = storeChat()
+  const { ws } = storeWs()
   useAsyncEffect({
     asyncFn: async () => await api.v1.chat.chatrooms.GET(),
     onSuccess: (chatRoomsData) => {
@@ -56,7 +58,7 @@ const GETChatRooms = () => {
 
       return setChatRooms(chatRoomsData || [])
     },
-    deps: [user],
+    deps: [user, ws],
   })
   return null
 }

--- a/src/hooks/api/queries/useQueryReview.ts
+++ b/src/hooks/api/queries/useQueryReview.ts
@@ -22,7 +22,6 @@ export const useQueryReview = (params: ReviewParams) => {
     queryFn: () =>
       api.v1.studies.groups(params.groupId).reviews.GET(undefined, {
         params: {
-          is_member: true,
           page: params.page,
           page_size: params.page_size,
           ordering: params.ordering,


### PR DESCRIPTION
## 💡 개요

- 기존엔 채팅 방을 다시 불러오지 않아 채팅방에 진입하여 메시지를 확인해도 읽지않은 메시지 개수에 변화가 없었으나, ws 객체 존재 여부에 따라 다시 요청을 시도하도록 변경함

## 📝 상세 내용

<img width="1118" height="228" alt="image" src="https://github.com/user-attachments/assets/9d2eb478-211a-4a88-b447-60328d075aaf" />

- ws 연결시/해제시 총 2번에 걸쳐 채팅방 목록을 불러옴

## ✅ 체크리스트

- [x] 코드에 불필요한 console.log 제거
- [ ] lint 검사 통과
- [ ] 테스트 통과
- [ ] 관련 문서/README 업데이트

## 🔗 관련 이슈

- close #6 #7 
