### PR TITLE
Feature/7 api 알림 로직 변경

### DIFF
--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -12,7 +12,7 @@ export const LOGIN_PAGE_URL = '/login'
 export const tokenManager = new TokenManager()
 export const apiFactory = new ApiClientFactory(tokenManager)
 
-const httpClient = apiFactory.createHttpClient(BASE_URL, throwHttpError)
+export const httpClient = apiFactory.createHttpClient(BASE_URL, throwHttpError)
 const requestExecutor = httpClient.getRequestExecutor()
 
 // 일반 http 통신은 트리 구조로 접근

--- a/src/components/notification/NotiCreateIcon.tsx
+++ b/src/components/notification/NotiCreateIcon.tsx
@@ -29,6 +29,12 @@ export const NOTIFICATION_STYLE: Record<NotificationType, NotificationStyle> = {
   STUDY_RECORD_CREATED: { Icon: NotebookPen, bg: '#CCFBF1', text: '#0D9488' },
 }
 
+export const DEFAULT_NOTIFICATION_STYLE: NotificationStyle = {
+  Icon: NotebookPen,
+  bg: '#E5E7EB',
+  text: '#6B7280',
+}
+
 /**
  * 아이콘과 색상을 입력받아 원형 배경이 적용된 아이콘을 만들어주는 메서드
  * @param {NotificationStyle} 아이콘(Icon), 아이콘 색상(text), 배경색상(bg)
@@ -46,4 +52,10 @@ export const createIconNode = ({ Icon, text, bg }: NotificationStyle) => {
       <Icon size={14} color={text} />
     </div>
   )
+}
+
+export const getNotificationStyle = (
+  type: NotificationType
+): NotificationStyle => {
+  return NOTIFICATION_STYLE[type] ?? DEFAULT_NOTIFICATION_STYLE
 }

--- a/src/components/notification/NotiPanel.tsx
+++ b/src/components/notification/NotiPanel.tsx
@@ -48,7 +48,7 @@ export const NotiPanel = ({
 const NotiHeader = () => {
   const { markAllAsRead } = storeNotification()
   const handleClick = async () => {
-    await api.v1.notifications.read$all.PATCH()
+    await api.v1.notifications.read$all.POST()
     markAllAsRead()
   }
   return (
@@ -117,7 +117,7 @@ const NotiItemList = () => {
   // TODO:제대로 요청/응답 오나 확인 필요
   // 현재 테스트 계정에 알림 없음
   const handleClick = async (n: UserNotification) => {
-    await api.v1.notifications(n.id).PATCH()
+    await api.v1.notifications(n.id).read.POST()
     window.location.href = n.back_url_link
   }
 

--- a/src/components/notification/NotiPanel.tsx
+++ b/src/components/notification/NotiPanel.tsx
@@ -1,11 +1,12 @@
 import { storeNotification, type filterKey } from '@/store/storeNotification'
 import { useMemo, useRef } from 'react'
-import { createIconNode, NOTIFICATION_STYLE } from './NotiCreateIcon'
+import { createIconNode, getNotificationStyle } from './NotiCreateIcon'
 import { AnimatePresence, motion } from 'framer-motion'
 import { usePanelClose } from '@/hooks/usePanelClose'
 import type { UserNotification } from '@/types/Notification'
 import { formatToMonthDay } from '@/hooks/useFormatDate'
-import { api } from '@/api/api'
+import { api, httpClient } from '@/api/api'
+import { toast } from 'react-toastify'
 
 // TODO
 // 1. store : 초기값 api 요청 로직 작성 v
@@ -116,9 +117,31 @@ const NotiItemList = () => {
 
   // TODO:제대로 요청/응답 오나 확인 필요
   // 현재 테스트 계정에 알림 없음
-  const handleClick = async (n: UserNotification) => {
-    await api.v1.notifications(n.id).read.POST()
-    window.location.href = n.back_url_link
+  const handleNotificationClick = async (notification: UserNotification) => {
+    const link = notification.back_url_link
+
+    if (!link) return
+
+    if (link.startsWith('http')) {
+      window.location.href = link
+      return
+    }
+
+    if (link.startsWith('/api')) {
+      try {
+        const cleaned = link.replace(/^\/api/, '')
+        const res = await httpClient.request(cleaned, 'GET')
+        console.log('API 호출 성공:', res.data)
+
+        // 필요 시 성공 후 특정 동작 실행
+        // navigate(...)
+        // open modal 등등...
+      } catch (err) {
+        console.error('API 호출 실패:', err)
+        toast.error('요청 처리 중 오류가 발생했습니다.')
+      }
+      return
+    }
   }
 
   return filtered.length === 0 ? (
@@ -130,10 +153,10 @@ const NotiItemList = () => {
           key={n.id}
           aria-label={`${n.id}. ${n.is_read ? '읽은' : '읽지 않은'} 알림`}
           className={`cursor-pointer p-4 transition-colors ${index !== 0 ? 'border-t border-gray-100' : ''} ${n.is_read ? 'bg-white' : 'bg-primary-50'}`}
-          onClick={() => handleClick(n)}
+          onClick={() => handleNotificationClick(n)}
         >
           <div className="relative flex items-start">
-            {createIconNode(NOTIFICATION_STYLE[n.type])}
+            {createIconNode(getNotificationStyle(n.type))}
 
             <div className="flex-1 pl-3">
               <p className="h-10 text-sm leading-5 tracking-[0px] text-gray-900">

--- a/src/test/TestG.tsx
+++ b/src/test/TestG.tsx
@@ -120,26 +120,28 @@ const TestG = () => {
       //   .kick$member.DELETE({
       //     target_member_uuid: serverDummyGroupMemberUUid[9].uuid,
       //   })
-      const res = await api.v1.studies.groups.GET(undefined, {
-        params: {
-          is_member: true,
-        },
-      })
-      // const res = await api.v1.studies.groups(serverDummyGroupUUid).GET()
+      // const res = await api.v1.studies.groups.GET(undefined, {
+      //   params: {
+      //     is_member: true,
+      //   },
+      // })
+      // // const res = await api.v1.studies.groups(serverDummyGroupUUid).GET()
 
-      const groupuuids = res.data.results.map((el) => el.uuid)
-      console.log(res)
+      // const groupuuids = res.data.results.map((el) => el.uuid)
+      // console.log(res)
 
-      for (const uuid of groupuuids) {
-        console.log(uuid)
+      // for (const uuid of groupuuids) {
+      //   console.log(uuid)
 
-        const resRev = api.v1.studies.groups(uuid).reviews.GET(undefined, {
-          params: {
-            page: 1,
-          },
-        })
-        console.log({ resRev })
-      }
+      //   const resRev = api.v1.studies.groups(uuid).reviews.GET(undefined, {
+      //     params: {
+      //       page: 1,
+      //     },
+      //   })
+      //   console.log({ resRev })
+      // }
+
+      const res = await api.v1.notifications.GET()
 
       // console.log({ accessToken })
 

--- a/src/types/ApiLink.ts
+++ b/src/types/ApiLink.ts
@@ -428,6 +428,8 @@ type NotificationApi = {
   GET: () => {
     res: {
       counts: { total: number; unread: number; read: number }
+      next: string | null
+      previous: string | null
       results: UserNotification[]
     }
   }

--- a/src/types/ApiLink.ts
+++ b/src/types/ApiLink.ts
@@ -432,13 +432,15 @@ type NotificationApi = {
     }
   }
   read$all: {
-    PATCH: () => {
+    POST: () => {
       res: BaseResponse
     }
   }
   (notification_id: number): {
-    PATCH: () => {
-      res: BaseResponse
+    read: {
+      POST: () => {
+        res: BaseResponse
+      }
     }
   }
   study: {


### PR DESCRIPTION
## 💡 개요

- 현재 없는 알림 타입이라도 오류를 발생 시키지 않도록 방어로직을 작성함
- 알림 클릭시 링크가 https:// 와 /api로 시작하는 2종류가 존재하는데 각각의 경우에 분기처리를 시행함
- 현재 대부분의 api로 시작하는 백 url이 목데이터라 404에러가 발생하는 관계로 정상적인 시연이 어려움

## 📝 상세 내용

<img width="1015" height="162" alt="image" src="https://github.com/user-attachments/assets/8403c80a-892c-4216-b5db-a6dd61ec73a1" />

- 클릭시 온 요청 url을 한번 래핑하여 클라이언트 객체에 전달하는 모습
- 목데이터에 직접 연결가능한 데이터가 없어 404 오류가 발생함

## ✅ 체크리스트

- [ ] 코드에 불필요한 console.log 제거
- [ ] lint 검사 통과
- [ ] 테스트 통과
- [ ] 관련 문서/README 업데이트

## 🔗 관련 이슈

- close #7  #5 
